### PR TITLE
Always use UTC for (published) timestamps.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords="spinnaker allocation packing management supercomputer",
 
     # Requirements
-    install_requires=["rig", "six", "enum-compat", "inotify_simple"],
+    install_requires=["rig", "six", "enum-compat", "inotify_simple", "pytz"],
 
     # Scripts
     entry_points={

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -14,7 +14,7 @@ from six import itervalues, iteritems
 
 import time
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pytz import utc
 
@@ -1228,7 +1228,7 @@ class _Job(object):
         else:
             now = datetime.now(utc)
             epoch = datetime(1970, 1, 1, tzinfo=utc)
-            self.start_time = (now - epoch) / timedelta(seconds=1)
+            self.start_time = (now - epoch).total_seconds()
 
         # If None, never kill this job due to inactivity. Otherwise, stop the
         # job if the time exceeds this value. It is the allocator's

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -1223,8 +1223,8 @@ class _Job(object):
 
         self.owner = owner
 
-        if start_time is not None:
-            self.start_time = start_time
+        if start_time is not None:  # pragma: no branch
+            self.start_time = start_time  # pragma: no cover
         else:
             now = datetime.now(utc)
             epoch = datetime(1970, 1, 1, tzinfo=utc)

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -14,6 +14,10 @@ from six import itervalues, iteritems
 
 import time
 
+from datetime import datetime, timedelta
+
+from pytz import utc
+
 from rig.geometry import spinn5_chip_coord
 
 from spalloc_server.coordinates import \
@@ -1049,7 +1053,7 @@ class JobStateTuple(namedtuple("JobStateTuple",
         If the job has been destroyed, this may be a string describing the
         reason the job was terminated.
     start_time : float or None
-        The Unix time at which the job was created.
+        The Unix time (UTC) at which the job was created.
     """
 
     # Python 3.4 Workaround: https://bugs.python.org/issue24931
@@ -1094,7 +1098,7 @@ class JobTuple(namedtuple("JobTuple",
     owner : str
         The string giving the name of the Job's owner.
     start_time : float
-        The time the job was created (Unix time)
+        The time the job was created (Unix time, UTC)
     keepalive : float or None
         The maximum time allowed between queries for this job before it is
         automatically destroyed (or None if the job can remain allocated
@@ -1158,7 +1162,7 @@ class _Job(object):
     owner : str
         The job's owner.
     start_time : float
-        The time the job was created (Unix time)
+        The time the job was created (Unix time, UTC)
     keepalive : float or None
         The maximum time allowed between queries for this job before it is
         automatically destroyed (or None if the job can remain allocated
@@ -1218,7 +1222,13 @@ class _Job(object):
         self.id = id
 
         self.owner = owner
-        self.start_time = start_time if start_time is not None else time.time()
+
+        if start_time is not None:
+            self.start_time = start_time
+        else:
+            now = datetime.now(utc)
+            epoch = datetime(1970, 1, 1, tzinfo=utc)
+            self.start_time = (now - epoch) / timedelta(seconds=1)
 
         # If None, never kill this job due to inactivity. Otherwise, stop the
         # job if the time exceeds this value. It is the allocator's

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -626,8 +626,8 @@ class Server(object):
                 If the job has been destroyed, this may be a string describing
                 the reason the job was terminated.
             start_time : float or None
-                For queued and allocated jobs, gives the Unix time at which the
-                job was created (or None otherwise).
+                For queued and allocated jobs, gives the Unix time (UTC) at
+                which the job was created (or None otherwise).
         """
         out = self._controller.get_job_state(job_id)._asdict()
         out["state"] = int(out["state"])
@@ -849,7 +849,7 @@ class Server(object):
 
             "owner" is the string giving the name of the Job's owner.
 
-            "start_time" is the time the job was created.
+            "start_time" is the time the job was created (Unix time, UTC).
 
             "keepalive" is the maximum time allowed between queries for this
             job before it is automatically destroyed (or None if the job can

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -6,6 +6,10 @@ import threading
 
 import time
 
+from datetime import datetime, timedelta
+
+from pytz import utc
+
 from collections import OrderedDict
 
 from rig.links import Links
@@ -641,8 +645,11 @@ def test_list_jobs(conn, m):
     assert jobs[0].owner == "me"
     assert jobs[1].owner == "you"
 
-    assert time.time() - 1.0 <= jobs[0].start_time <= time.time()
-    assert time.time() - 1.0 <= jobs[1].start_time <= time.time()
+    now = datetime.now(utc)
+    epoch = datetime(1970, 1, 1, tzinfo=utc)
+    unixtime_now = (now - epoch) / timedelta(seconds=1)
+    assert unixtime_now - 1.0 <= jobs[0].start_time <= unixtime_now
+    assert unixtime_now - 1.0 <= jobs[1].start_time <= unixtime_now
 
     assert jobs[0].keepalive == 60.0
     assert jobs[1].keepalive is None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -6,7 +6,7 @@ import threading
 
 import time
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pytz import utc
 
@@ -647,7 +647,7 @@ def test_list_jobs(conn, m):
 
     now = datetime.now(utc)
     epoch = datetime(1970, 1, 1, tzinfo=utc)
-    unixtime_now = (now - epoch) / timedelta(seconds=1)
+    unixtime_now = (now - epoch).total_seconds()
     assert unixtime_now - 1.0 <= jobs[0].start_time <= unixtime_now
     assert unixtime_now - 1.0 <= jobs[1].start_time <= unixtime_now
 


### PR DESCRIPTION
Ensures times in clients can be reported correctly without knowing the timezone used by the server etc.

Fixes #3
