### PR TITLE
Switch controller to spinnman

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six
 enum-compat
 inotify_simple
 pytz
+SpiNNMan

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords="spinnaker allocation packing management supercomputer",
 
     # Requirements
-    install_requires=["rig", "six", "enum-compat", "inotify_simple", "pytz", "SpiNNMan"],
+    install_requires=["rig", "six", "enum-compat", "inotify_simple", "pytz", "SpiNNMan >= 3.0.0, < 4.0.0"],
 
     # Scripts
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords="spinnaker allocation packing management supercomputer",
 
     # Requirements
-    install_requires=["rig", "six", "enum-compat", "inotify_simple", "pytz"],
+    install_requires=["rig", "six", "enum-compat", "inotify_simple", "pytz", "SpiNNMan"],
 
     # Scripts
     entry_points={

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -144,6 +144,13 @@ class AsyncBMPController(object):
         self._thread.join()
 
     def _set_board_state(self, state, board):
+        """Set the power state of a board.
+        
+        :param state: What to set the state to. True for on, False for off
+        :type state: bool
+        :param board: Which board or boards to set the state of
+        :type board: int or iterable
+        """
         try:
             self._bc.set_power(state=state, board=board)
             return True
@@ -154,6 +161,15 @@ class AsyncBMPController(object):
             return False
 
     def _set_link_state(self, link, enable, board):
+        """Set the power state of a link.
+
+        :param link: The link (direction) to set the enable-state of.
+        :type link: value in Links enum
+        :param state: What to set the state to. True for on, False for off.
+        :type state: bool
+        :param board: Which board or boards to set the link enable-state of.
+        :type board: int or iterable
+        """
         try:
             fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
             self._bc.write_fpga_reg(fpga, addr, not enable, board=board)
@@ -163,7 +179,6 @@ class AsyncBMPController(object):
             # much we can do for the end-user.
             logging.exception("Failed to set link state.")
             return False
-
 
     def _run(self):
         """The background thread for interacting with the BMP.

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -90,6 +90,10 @@ class AsyncBMPController(object):
             another thread. Success is a bool which is True if the command
             completed successfully and False if it did not (or was cancelled).
         """
+        # Verify that our arguments are sane
+        board = int(board)
+        state = bool(state)
+        on_done.__call__
         with self._lock:
             assert not self._stop
 
@@ -123,6 +127,10 @@ class AsyncBMPController(object):
             another thread. Success is a bool which is True if the command
             completed successfully and False if it did not (or was cancelled).
         """
+        # Verify that our arguments are sane
+        board = int(board)
+        enable = bool(enable)
+        on_done.__call__
         with self._lock:
             assert not self._stop
 
@@ -152,11 +160,10 @@ class AsyncBMPController(object):
         :type board: int or iterable
         """
         try:
-            # TODO: What about cabinet and frame?
             if state:
-                self._transciever.power_on(board)
+                self._transciever.power_on(board=board, frame=0, cabinet=0)
             else:
-                self._transciever.power_off(board)
+                self._transciever.power_off(board, frame=0, cabinet=0)
             return True
         except IOError:
             # Communication issue with the machine, log it but not
@@ -176,8 +183,8 @@ class AsyncBMPController(object):
         """
         try:
             fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
-            # TODO: What about cabinet and frame?
-            self._transciever.write_fpga_register(fpga, addr, int(not enable), board=board)
+            self._transciever.write_fpga_register(fpga, addr, int(not enable),
+                                            board=board, frame=0, cabinet=0)
             return True
         except IOError:
             # Communication issue with the machine, log it but not
@@ -273,8 +280,7 @@ class AsyncBMPController(object):
         with self._lock:
             if not self._link_requests:
                 return None
-            else:
-                return self._link_requests.popleft()
+            return self._link_requests.popleft()
 
 
 class _PowerRequest(namedtuple("_PowerRequest", "state board on_done")):


### PR DESCRIPTION
Converts spalloc to use an enum for link directions that is defined inside spalloc instead of using a version from rig.

Currently some problems though, as there's additional coordinates in the SpiNNMan code that Rig lacked. What should the `cabinet` and `frame` be?