### PR TITLE
Android

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 six
 enum-compat
-inotify_simple
 pytz
 SpiNNMan
-SpiNNMachine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six
 enum-compat
 pytz
-SpiNNMan
+SpiNNMan >=1!4.0.0a1, <1!5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-rig
 six
 enum-compat
 inotify_simple

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ setup(
 
     # Requirements
     install_requires=[
-        "six", "enum-compat", "inotify_simple", "pytz",
-        "SpiNNMan >= 3.0.0, < 4.0.0"],
+        "six", "enum-compat", "pytz", "SpiNNMan >= 3.0.0, < 4.0.0"],
 
     # Scripts
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 
     # Requirements
     install_requires=[
-        "six", "enum-compat", "pytz", "SpiNNMan >= 3.0.0, < 4.0.0"],
+        "six", "enum-compat", "pytz", "SpiNNMan >=1!4.0.0a1, <1!5.0.0"],
 
     # Scripts
     entry_points={


### PR DESCRIPTION
These are the fixes to support running the spalloc server on an Android phone, useful for running small detached installations (e.g., at Capo Caccia).