### PR TITLE
Server rework

### DIFF
--- a/spalloc_server/allocator.py
+++ b/spalloc_server/allocator.py
@@ -4,18 +4,14 @@ functionality of a machine.
 """
 
 from enum import Enum
-
 from collections import deque
-
 from math import ceil
-
 from six import next
 
-from spalloc_server.links import Links
-
-from spalloc_server.pack_tree import PackTree
-from spalloc_server.area_to_rect import area_to_rect
-from spalloc_server.coordinates import board_down_link, WrapAround
+from .links import Links
+from .pack_tree import PackTree
+from .area_to_rect import area_to_rect
+from .coordinates import board_down_link, WrapAround
 
 
 class Allocator(object):
@@ -94,7 +90,7 @@ class Allocator(object):
 
     def _alloc_triads_possible(self, width, height, max_dead_boards=None,
                                max_dead_links=None, require_torus=False,
-                               min_ratio=0.0):
+                               min_ratio=0.0):  # @UnusedVariable
         """Is it guaranteed that the specified allocation *could* succeed if
         enough of the machine is free?
 
@@ -164,7 +160,7 @@ class Allocator(object):
 
     def _alloc_triads(self, width, height, max_dead_boards=None,
                       max_dead_links=None, require_torus=False,
-                      min_ratio=0.0):
+                      min_ratio=0.0):  # @UnusedVariable
         """Allocate a rectangular block of triads of interconnected boards.
 
         Parameters
@@ -398,9 +394,10 @@ class Allocator(object):
 
         return (allocation_id, cf.boards, cf.periphery, cf.torus)
 
-    def _alloc_board_possible(self, x=None, y=None, z=None,
-                              max_dead_boards=None, max_dead_links=None,
-                              require_torus=False, min_ratio=0.0):
+    def _alloc_board_possible(
+            self, x=None, y=None, z=None,
+            max_dead_boards=None, max_dead_links=None,  # @UnusedVariable
+            require_torus=False, min_ratio=0.0):  # @UnusedVariable
         """Is it guaranteed that the specified allocation *could* succeed if
         enough of the machine is free?
 
@@ -450,9 +447,10 @@ class Allocator(object):
         # Should be possible!
         return True
 
-    def _alloc_board(self, x=None, y=None, z=None,
-                     max_dead_boards=None, max_dead_links=None,
-                     require_torus=False, min_ratio=0.0):
+    def _alloc_board(
+            self, x=None, y=None, z=None,
+            max_dead_boards=None, max_dead_links=None,  # @UnusedVariable
+            require_torus=False, min_ratio=0.0):  # @UnusedVariable
         """Allocate a single board, optionally specifying a specific board to
         allocate.
 
@@ -532,7 +530,8 @@ class Allocator(object):
         # The desired board was not available in an already-allocated triad.
         # Attempt to request that triad.
 
-        def has_at_least_one_working_board(x, y, width, height):
+        def has_at_least_one_working_board(
+                x, y, width, height):  # @UnusedVariable
             num_dead = 0
             for z in range(3):
                 if (x, y, z) in self.dead_boards:
@@ -559,9 +558,10 @@ class Allocator(object):
         # Recursing will return a board from the triad
         return self._alloc_board(x, y, z)
 
-    def _alloc_type(self, x_or_num_or_width=None, y_or_height=None, z=None,
-                    max_dead_boards=None, max_dead_links=None,
-                    require_torus=False, min_ratio=0.0):
+    def _alloc_type(
+            self, x_or_num_or_width=None, y_or_height=None, z=None,
+            max_dead_boards=None, max_dead_links=None,  # @UnusedVariable
+            require_torus=False, min_ratio=0.0):  # @UnusedVariable
         """Returns the type of allocation the user is attempting to make (and
         fails if it is invalid.
 
@@ -905,8 +905,8 @@ class _CandidateFilter(object):
                 if (x1, y1, z1, link) in self.dead_links:
                     continue
 
-                x2, y2, z2, _ = board_down_link(x1, y1, z1, link,
-                                                self.width, self.height)
+                x2, y2, z2, _ = board_down_link(
+                    x1, y1, z1, link, self.width, self.height)
 
                 # Only process links to boards in the specified range
                 if (x <= x2 < x + width and
@@ -956,8 +956,8 @@ class _CandidateFilter(object):
         for x1, y1, z1 in boards:
             for link in Links:
                 is_dead = (x1, y1, z1, link) in self.dead_links
-                x2, y2, z2, wrapped = board_down_link(x1, y1, z1, link,
-                                                      self.width, self.height)
+                x2, y2, z2, wrapped = board_down_link(
+                    x1, y1, z1, link, self.width, self.height)
                 in_set = (x2, y2, z2) in boards
 
                 if in_set:

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -3,14 +3,12 @@ a whole rack.
 """
 
 import threading
-
+import logging
 from collections import namedtuple, deque
 
 from spalloc_server.links import Links
 from spinnman.transceiver import create_transceiver_from_hostname
-
-import logging
-from spinnman.model.bmp_connection_data import BMPConnectionData
+from spinnman.model import BMPConnectionData
 
 
 class AsyncBMPController(object):

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -6,9 +6,10 @@ import threading
 import logging
 from collections import namedtuple, deque
 
-from spalloc_server.links import Links
 from spinnman.transceiver import create_transceiver_from_hostname
 from spinnman.model import BMPConnectionData
+
+from .links import Links
 
 
 class AsyncBMPController(object):
@@ -47,8 +48,8 @@ class AsyncBMPController(object):
         self._on_thread_start = on_thread_start
 
         self._transceiver = create_transceiver_from_hostname(
-            None, 5,
-            bmp_connection_data=[BMPConnectionData(0, 0, hostname, [0], None)])
+            None, 5, bmp_connection_data=[
+                BMPConnectionData(0, 0, hostname, [0], None)])
 
         self._stop = False
 
@@ -74,8 +75,8 @@ class AsyncBMPController(object):
         """When used as a context manager, make requests 'atomic'."""
         self._lock.acquire()
 
-    def __exit__(self, type=None, value=None,  # @ReservedAssignment
-                 traceback=None):
+    def __exit__(self, type=None,  # @ReservedAssignment
+                 value=None, traceback=None):  # @UnusedVariable
         self._lock.release()
 
     def set_power(self, board, state, on_done):
@@ -185,9 +186,8 @@ class AsyncBMPController(object):
         """
         try:
             fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
-            self._transceiver.write_fpga_register(fpga, addr, int(not enable),
-                                                  board=board, frame=0,
-                                                  cabinet=0)
+            self._transceiver.write_fpga_register(
+                fpga, addr, int(not enable), board=board, frame=0, cabinet=0)
             return True
         except IOError:
             # Communication issue with the machine, log it but not

--- a/spalloc_server/configuration.py
+++ b/spalloc_server/configuration.py
@@ -93,15 +93,12 @@ Configuration File API Reference
 """
 
 from collections import namedtuple
-
 import re
 import csv
-
 from itertools import chain
-
 from six import iteritems, itervalues
 
-from spalloc_server.coordinates import chip_to_board
+from .coordinates import chip_to_board
 
 
 class Configuration(namedtuple("Configuration",

--- a/spalloc_server/configuration_reloader.py
+++ b/spalloc_server/configuration_reloader.py
@@ -1,0 +1,91 @@
+import signal
+import logging as log
+from six import add_metaclass
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+
+_SIGHUP = signal.SIGHUP if hasattr(signal, "SIGHUP") else None
+
+@add_metaclass(AbstractBase)
+class ConfigurationReloader(object):
+    def __init__(self, configuration_file, callback):
+        self._config_filename = configuration_file
+        # Set up SIGHUP signal handler for config file reloading
+        if _SIGHUP is not None:
+            signal.signal(_SIGHUP, self._sighup_handler)
+            self._callback = callback
+            log.info("configuration reloading enabled: "
+                     "send SIGHUP to trigger reload")
+
+    def _sighup_handler(self, signum, frame):  # @UnusedVariable
+        """Handler for SIGHUP. If such a signal is delivered, will trigger a
+        reread of the configuration file.
+
+        Parameters
+        ----------
+        signum : int
+        frame :
+        """
+        if signum == _SIGHUP:
+            self._reload_config = True
+            self._callback()
+
+    @property
+    def config_needs_reloading(self):
+        return self._reload_config
+
+    @property
+    def configuration_file(self):
+        return self._config_filename
+
+    def read_config_file(self):
+        """(Re-)read the server configuration.
+
+        If reading of the config file fails, the current configuration is
+        retained, unchanged.
+
+        Returns
+        -------
+        bool
+            True if reading succeeded, False otherwise.
+        """
+        self._reload_config = False
+        try:
+            with open(self._config_filename, "r") as f:
+                config_script = f.read()
+        except (IOError, OSError):  # pragma: no cover
+            log.exception("Could not read config file %s",
+                          self._config_filename)
+            return False
+
+        try:
+            parsed_config = self._parse_config(config_script)
+        except:
+            # Executing the config file failed, don't update any settings
+            log.exception("Error while evaluating config file %s",
+                          self._config_filename)
+            return False
+
+        # Check that the configuration is meaningful
+        validated = self._validate_config(parsed_config)
+        if validated is None:
+            log.error("Configuration loaded from %s was not valid",
+                      self._config_filename)
+            return False
+
+        # Update the configuration
+        self._load_valid_config(validated)
+
+        log.info("Config file %s read successfully.", self._config_filename)
+        return True
+
+    @abstractmethod
+    def _parse_config(self, config_file_contents):
+        pass
+
+    @abstractmethod
+    def _validate_config(self, parsed_config):
+        pass
+
+    @abstractmethod
+    def _load_valid_config(self, validated_config):
+        pass

--- a/spalloc_server/configuration_reloader.py
+++ b/spalloc_server/configuration_reloader.py
@@ -7,6 +7,11 @@ _SIGHUP = signal.SIGHUP if hasattr(signal, "SIGHUP") else None
 
 @add_metaclass(AbstractBase)
 class ConfigurationReloader(object):
+    """A class that provides the core knowledge about how to load and reload\
+    some configuration when a signal is sent to the process. It is probably\
+    wise to only make one concrete subclass instance of this class at a\
+    time."""
+
     def __init__(self, configuration_file, callback):
         self._config_filename = configuration_file
         # Set up SIGHUP signal handler for config file reloading
@@ -31,17 +36,19 @@ class ConfigurationReloader(object):
 
     @property
     def config_needs_reloading(self):
+        """Describes whether a reload is pending."""
         return self._reload_config
 
     @property
     def configuration_file(self):
+        """Describes where the configuration will be (re)loaded from.""" 
         return self._config_filename
 
     def read_config_file(self):
         """(Re-)read the server configuration.
 
-        If reading of the config file fails, the current configuration is
-        retained, unchanged.
+        If reading of the configuration file fails, the current configuration
+        is retained, unchanged.
 
         Returns
         -------
@@ -80,12 +87,49 @@ class ConfigurationReloader(object):
 
     @abstractmethod
     def _parse_config(self, config_file_contents):
-        pass
+        """How to parse the contents of the configuration file. Note that\
+        this is intended to be a basic parse, not an extended semantic check\
+        for high-level validity.
+
+        Parameters
+        ----------
+        config_file_contents : str
+
+        Returns
+        -------
+        object
+            Some parsed description of the configuration. Will be passed to\
+            validator method.
+
+        Throws
+        ------
+        Any exception or error if the parse fails
+        """
 
     @abstractmethod
     def _validate_config(self, parsed_config):
-        pass
+        """How to check the parsed contents of the configuration for\
+        high-level semantic validity.
+
+        Parameters
+        ----------
+        parsed_config : object
+            Whatever was produced by the parser method.
+
+        Returns
+        -------
+        object
+            The validated configuration object, or None if the configuration\
+            was invalid.
+        """
 
     @abstractmethod
     def _load_valid_config(self, validated_config):
-        pass
+        """How to install the validated configuration. Not expected to have\
+        a failure mode under normal circumstances.
+
+        Parameters
+        ----------
+        validated_config : object
+            Whatever was produced by the validator method.
+        """

--- a/spalloc_server/configuration_reloader.py
+++ b/spalloc_server/configuration_reloader.py
@@ -5,6 +5,7 @@ from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 _SIGHUP = signal.SIGHUP if hasattr(signal, "SIGHUP") else None
 
+
 @add_metaclass(AbstractBase)
 class ConfigurationReloader(object):
     """A class that provides the core knowledge about how to load and reload\
@@ -41,7 +42,7 @@ class ConfigurationReloader(object):
 
     @property
     def configuration_file(self):
-        """Describes where the configuration will be (re)loaded from.""" 
+        """Describes where the configuration will be (re)loaded from."""
         return self._config_filename
 
     def read_config_file(self):

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -22,7 +22,7 @@ from spalloc_server.coordinates import \
     board_to_chip, chip_to_board, triad_dimensions_to_chips, WrapAround
 from spalloc_server.job_queue import JobQueue
 from spalloc_server.async_bmp_controller import AsyncBMPController
-from spinn_machine.spinnaker_triad_geometry import SpiNNakerTriadGeometry
+from spinn_machine import SpiNNakerTriadGeometry
 
 
 class Controller(object):

--- a/spalloc_server/coordinates.py
+++ b/spalloc_server/coordinates.py
@@ -121,7 +121,7 @@ from enum import IntEnum
 from six import iteritems
 
 from spalloc_server.links import Links
-from spinn_machine.spinnaker_triad_geometry import SpiNNakerTriadGeometry
+from spinn_machine import SpiNNakerTriadGeometry
 
 
 link_to_vector = {

--- a/spalloc_server/coordinates.py
+++ b/spalloc_server/coordinates.py
@@ -120,8 +120,9 @@ systems.
 from enum import IntEnum
 from six import iteritems
 
-from spalloc_server.links import Links
 from spinn_machine import SpiNNakerTriadGeometry
+
+from .links import Links
 
 
 link_to_vector = {

--- a/spalloc_server/job_queue.py
+++ b/spalloc_server/job_queue.py
@@ -2,10 +2,9 @@
 """
 
 from collections import deque, OrderedDict
-
 from six import itervalues
 
-from spalloc_server.allocator import Allocator
+from .allocator import Allocator
 
 
 class JobQueue(object):
@@ -119,7 +118,8 @@ class JobQueue(object):
         """
         self._postpone_queue_management += 1
 
-    def __exit__(self, Type=None, value=None, traceback=None):
+    def __exit__(self,
+                 Type=None, value=None, traceback=None):  # @UnusedVariable
         self._postpone_queue_management -= 1
         self._regenerate_queues()
 

--- a/spalloc_server/pack_tree.py
+++ b/spalloc_server/pack_tree.py
@@ -6,7 +6,7 @@ otherwise a relatively generic 2D packing algorithm.
 """
 
 
-from spalloc_server.area_to_rect import area_to_rect
+from .area_to_rect import area_to_rect
 
 
 class PackTree(object):
@@ -65,10 +65,9 @@ class PackTree(object):
         assert self.children is None
         assert not self.allocated
 
-        self.children = (PackTree(self.x, self.y,
-                                  self.width, (y - self.y)),
-                         PackTree(self.x, y,
-                                  self.width, self.height - (y - self.y)))
+        self.children = (
+            PackTree(self.x, self.y, self.width, (y - self.y)),
+            PackTree(self.x, y, self.width, self.height - (y - self.y)))
 
     def vsplit(self, x):
         """Split this node along the Y axis.
@@ -88,10 +87,9 @@ class PackTree(object):
         assert self.children is None
         assert not self.allocated
 
-        self.children = (PackTree(self.x, self.y,
-                                  (x - self.x), self.height),
-                         PackTree(x, self.y,
-                                  self.width - (x - self.x), self.height))
+        self.children = (
+            PackTree(self.x, self.y, (x - self.x), self.height),
+            PackTree(x, self.y, self.width - (x - self.x), self.height))
 
     def alloc(self, width, height, candidate_filter=None):
         """Attempt to allocate a rectangular region of a specified size.

--- a/spalloc_server/polling_server_core.py
+++ b/spalloc_server/polling_server_core.py
@@ -1,0 +1,108 @@
+from errno import EWOULDBLOCK
+import select
+import socket
+
+BUFFER_SIZE = 1024
+
+
+class PollingServerCore(object):
+    """Wrapper around the operating system's poll() call. Also knows the\
+    basics of making sockets.
+    """
+    def __init__(self):
+        # The poll object used for listening for connections
+        self._poll = None
+        if hasattr(select, "poll"):
+            self._poll = select.poll()  # @UndefinedVariable
+
+        # Used to map file descriptors to channels
+        self._fdmap = {}
+
+        # This socket pair is used by background threads to interrupt the main
+        # event loop.
+        self._notify_send, self._notify_recv = None, None
+        if hasattr(socket, "socketpair"):
+            self._notify_send, self._notify_recv = socket.socketpair()
+        else:
+
+            # Create your own socket pair
+            temp_sock = socket.socket()
+            temp_sock.setblocking(True)
+            temp_sock.bind(('', 0))
+            port = temp_sock.getsockname()[1]
+            temp_sock.listen(1)
+            self._notify_send = socket.socket()
+            self._notify_send.setblocking(False)
+            try:
+                self._notify_send.connect(('localhost', port))
+            except socket.error as err:
+                # EWOULDBLOCK is not an error, as the socket is non-blocking
+                if err.errno != EWOULDBLOCK:
+                    raise
+            self._notify_recv, _ = temp_sock.accept()
+        self.register_channel(self._notify_recv)
+
+    def register_channel(self, channel):
+        """Register a channel (file, socket, etc.) for being reported via the
+        :py:meth:`.ready_channels` method.
+        """
+        if self._poll is not None:
+            self._poll.register(
+                channel.fileno(), select.POLLIN)  # @UndefinedVariable
+        self._fdmap[channel.fileno()] = channel
+
+    def unregister_channel(self, channel):
+        """Unregister a channel (file, socket, etc.) for being reported via
+        the :py:meth:`.ready_channels` method.
+        """
+        if self._poll is not None:
+            self._poll.unregister(channel)
+        if channel.fileno() in self._fdmap:
+            del self._fdmap[channel.fileno()]
+
+    def ready_channels(self, timeout_check_interval):
+        """Waits up to timeout_check_interval milliseconds for a channel to
+        become readable. Multiple channels may become readable at once.
+
+        :return: An iterable listing the channels that are currently
+                 readable. Can be empty if the poller is woken via the
+                 :py:meth:`.wake` call.
+        """
+        if self._poll is not None:
+            events = self._poll.poll(timeout_check_interval)
+            for fd, _ in events:
+                if fd == self._notify_recv.fileno():
+                    self._notify_recv.recv(BUFFER_SIZE)
+                else:
+                    yield self._fdmap[fd]
+        else:
+            channels = self._fdmap.values()
+            readable, _, _ = select.select(
+                channels, [], [], timeout_check_interval)
+            for channel in readable:
+                if channel == self._notify_recv:
+                    self._notify_recv.recv(BUFFER_SIZE)
+                else:
+                    yield channel
+
+    def wake(self):
+        """Notify the waiting thread that something has happened.
+
+        Calling this method simply wakes up the waiting thread (which will be
+        waiting in :py:meth:`.ready_channels`) causing it to perform all its
+        usual checks and processing steps.
+        """
+        self._notify_send.send(b"x")
+
+    def _open_server_socket(self, ipaddress, port):
+        """Create a new server socket.
+
+        :param str ipaddress: The local address of the socket.
+        :param int port: The local port of the socket.
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((ipaddress, port))
+        sock.listen(5)
+        self.register_channel(sock)
+        return sock

--- a/spalloc_server/polling_server_core.py
+++ b/spalloc_server/polling_server_core.py
@@ -46,7 +46,7 @@ class PollingServerCore(object):
         self._notify_send, self._notify_recv = None, None
         if hasattr(socket, "socketpair"):
             self._notify_send, self._notify_recv = socket.socketpair()
-        else:
+        else:  # pragma: no cover
             # Create your own socket pair
             self._notify_send, self._notify_recv = _simulated_socketpair()
         self.register_channel(self._notify_recv)
@@ -84,7 +84,7 @@ class PollingServerCore(object):
                     self._notify_recv.recv(BUFFER_SIZE)
                 else:
                     yield self._fdmap[fd]
-        else:
+        else:  # pragma: no cover
             channels = self._fdmap.values()
             readable, _, _ = select.select(
                 channels, [], [], timeout_check_interval)

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -181,24 +181,24 @@ class Server(PollingServerCore, ConfigurationReloader):
         return new
 
     @overrides(super_class_method=ConfigurationReloader._load_valid_config)
-    def _load_valid_config(self, new):
+    def _load_valid_config(self, validated_config):
         old = self._configuration
-        self._configuration = new
+        self._configuration = validated_config
 
         # Restart the server if the port or IP has changed (or if the server
         # has not yet been started...)
-        if new.ip != old.ip or self._server_socket is None:
+        if validated_config.ip != old.ip or self._server_socket is None:
             # Close all open connections
             if self._close():  # pragma: no cover
                 sleep(0.25)  # Ugly hack; fully release socket now
 
-            # Create a new server socket
-            self._open_server_socket(new.ip, self._port)
+            # Create a validated_config server socket
+            self._open_server_socket(validated_config.ip, self._port)
 
         # Update the controller
-        self._controller.max_retired_jobs = new.max_retired_jobs
+        self._controller.max_retired_jobs = validated_config.max_retired_jobs
         self._controller.machines = OrderedDict(
-            (m.name, m) for m in new.machines)
+            (m.name, m) for m in validated_config.machines)
 
     def _close(self):
         """Close all server sockets and disconnect all client connections."""

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -18,10 +18,10 @@ from time import sleep
 from spinn_utilities.overrides import overrides
 
 from spalloc_server import __version__, coordinates, configuration
-from .configuration import Configuration
-from .controller import Controller
-from .polling_server_core import PollingServerCore
-from .configuration_reloader import ConfigurationReloader
+from spalloc_server.configuration import Configuration
+from spalloc_server.controller import Controller
+from spalloc_server.polling_server_core import PollingServerCore
+from spalloc_server.configuration_reloader import ConfigurationReloader
 
 BUFFER_SIZE = 1024
 

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -5,25 +5,23 @@ SpiNNaker Partitioning Server, containing the :py:func:`function <.main>` which
 is mapped to the ``spalloc-server`` command-line tool.
 """
 
-from os import path
-import logging
-import pickle
-import socket
-import select
-import signal
-import threading
-import json
-import argparse
-import time
-import errno
-
+from argparse import ArgumentParser
 from collections import OrderedDict
-
+from json import dumps as json, loads as dejson
+import logging as log 
+from os import path
+from pickle import dump as pickle, load as unpickle
 from six import iteritems, string_types
+from threading import Thread
+from time import sleep
+
+from spinn_utilities.overrides import overrides
 
 from spalloc_server import __version__, coordinates, configuration
-from spalloc_server.configuration import Configuration
-from spalloc_server.controller import Controller
+from .configuration import Configuration
+from .controller import Controller
+from .polling_server_core import PollingServerCore
+from .configuration_reloader import ConfigurationReloader
 
 BUFFER_SIZE = 1024
 
@@ -41,96 +39,7 @@ def spalloc_command(f):
     return f
 
 
-class PollingServerCore(object):
-    """Wrapper around the operating system's poll() call.
-    """
-    def __init__(self):
-        # The poll object used for listening for connections
-        self._poll = None
-        if hasattr(select, "poll"):
-            self._poll = select.poll()  # @UndefinedVariable
-
-        # Used to map file descriptors to channels
-        self._fdmap = {}
-
-        # This socket pair is used by background threads to interrupt the main
-        # event loop.
-        self._notify_send, self._notify_recv = None, None
-        if hasattr(socket, "socketpair"):
-            self._notify_send, self._notify_recv = socket.socketpair()
-        else:
-
-            # Create your own socket pair
-            temp_sock = socket.socket()
-            temp_sock.setblocking(True)
-            temp_sock.bind(('', 0))
-            port = temp_sock.getsockname()[1]
-            temp_sock.listen(1)
-            self._notify_send = socket.socket()
-            self._notify_send.setblocking(False)
-            try:
-                self._notify_send.connect(('localhost', port))
-            except socket.error as err:
-                # EWOULDBLOCK is not an error, as the socket is non-blocking
-                if err.errno != errno.EWOULDBLOCK:
-                    raise
-            self._notify_recv, _ = temp_sock.accept()
-        self.register_channel(self._notify_recv)
-
-    def register_channel(self, channel):
-        """Register a channel (file, socket, etc.) for being reported via the
-        :py:meth:`.ready_channels` method.
-        """
-        if self._poll is not None:
-            self._poll.register(
-                channel.fileno(), select.POLLIN)  # @UndefinedVariable
-        self._fdmap[channel.fileno()] = channel
-
-    def unregister_channel(self, channel):
-        """Unregister a channel (file, socket, etc.) for being reported via
-        the :py:meth:`.ready_channels` method.
-        """
-        if self._poll is not None:
-            self._poll.unregister(channel)
-        if channel.fileno() in self._fdmap:
-            del self._fdmap[channel.fileno()]
-
-    def ready_channels(self, timeout_check_interval):
-        """Waits up to timeout_check_interval milliseconds for a channel to
-        become readable. Multiple channels may become readable at once.
-
-        :return: An iterable listing the channels that are currently
-                 readable. Can be empty if the poller is woken via the
-                 :py:meth:`.wake` call.
-        """
-        if self._poll is not None:
-            events = self._poll.poll(timeout_check_interval)
-            for fd, _ in events:
-                if fd == self._notify_recv.fileno():
-                    self._notify_recv.recv(BUFFER_SIZE)
-                else:
-                    yield self._fdmap[fd]
-        else:
-            channels = self._fdmap.values()
-            readable, _, _ = select.select(
-                channels, [], [], timeout_check_interval)
-            for channel in readable:
-                if channel == self._notify_recv:
-                    self._notify_recv.recv(BUFFER_SIZE)
-                else:
-                    yield channel
-
-    def wake(self):
-        """Notify the waiting thread that something has happened.
-
-        Calling this method simply wakes up the waiting thread (which will be
-        waiting in :py:meth:`.ready_channels`) causing it to perform all its
-        usual checks and processing steps.
-        """
-        self._notify_send.send(b"x")
-
-
-class Server(PollingServerCore):
+class Server(PollingServerCore, ConfigurationReloader):
     """A TCP server which manages, power, partitioning and scheduling of jobs
     on SpiNNaker machines.
 
@@ -175,8 +84,8 @@ class Server(PollingServerCore):
             Which port to listen on. Defaults to 22244.
         """
         PollingServerCore.__init__(self)
+        ConfigurationReloader.__init__(self, config_filename, self.wake)
 
-        self._config_filename = config_filename
         self._cold_start = cold_start
         self._port = port
 
@@ -184,8 +93,7 @@ class Server(PollingServerCore):
         self._stop = False
 
         # The background thread in which the server will run
-        self._server_thread = threading.Thread(target=self._run,
-                                               name="Server Thread")
+        self._server_thread = Thread(target=self._run, name="Server Thread")
 
         # Currently open sockets to clients. Once server started, should only
         # be accessed from the server thread.
@@ -207,25 +115,26 @@ class Server(PollingServerCore):
         self._configuration = Configuration()
 
         # Infer the saved-state location
-        self._state_filename = self._get_state_filename(self._config_filename)
+        self._state_filename = \
+            self._get_state_filename(self.configuration_file)
 
         # Attempt to restore saved state if required
         self._controller = None
         if not self._cold_start and path.isfile(self._state_filename):
             try:
                 with open(self._state_filename, "rb") as f:
-                    self._controller = pickle.load(f)
-                logging.info("Server warm-starting from %s.",
-                             self._state_filename)
+                    self._controller = unpickle(f)
+                log.info("Server warm-starting from %s.",
+                         self._state_filename)
             except:
                 # Some other error occurred during unpickling.
-                logging.exception(
+                log.exception(
                     "Server state could not be unpacked from %s.",
                     self._state_filename)
 
         # Perform cold-start if no saved state was loaded
         if self._controller is None:
-            logging.info("Server cold-starting.")
+            log.info("Server cold-starting.")
             self._controller = Controller()
 
         # Notify the background thread when something changes in the background
@@ -234,12 +143,8 @@ class Server(PollingServerCore):
 
         # Read configuration file. This must succeed when the server is first
         # being started.
-        if not self._read_config_file():
+        if not self.read_config_file():
             raise Exception("Config file could not be loaded.")
-
-        # Set up SIGHUP signal handler for config file reloading
-        if hasattr(signal, "SIGHUP"):
-            signal.signal(signal.SIGHUP, self._sighup_handler)
 
         # Start the server
         self._server_thread.start()
@@ -260,94 +165,40 @@ class Server(PollingServerCore):
         filename = ".{}.state.{}".format(basename, __version__)
         return path.join(dirname, filename)
 
-    def _sighup_handler(self, signum, frame):
-        """Handler for SIGHUP. If such a signal is delivered, will trigger a
-        reread of the configuration file.
+    @overrides(super_class_method=ConfigurationReloader._parse_config)
+    def _parse_config(self, config_file_contents):
+        g = {}
+        g.update(configuration.__dict__)
+        g.update(coordinates.__dict__)
+        exec(config_file_contents, g)
+        return g
 
-        Parameters
-        ----------
-        signum : int
-        frame :
-        """
-        if signum == signal.SIGHUP:  # @UndefinedVariable
-            self._reload_config = True
-            self.wake()
+    @overrides(super_class_method=ConfigurationReloader._validate_config)
+    def _validate_config(self, parsed_config):
+        new = parsed_config.get("configuration", None)
+        if new is None or not isinstance(new, Configuration):
+            return None
+        return new
 
-    def _read_config_file(self):
-        """(Re-)read the server configuration.
-
-        If reading of the config file fails, the current configuration is
-        retained, unchanged.
-
-        Returns
-        -------
-        bool
-            True if reading succeeded, False otherwise.
-        """
-        self._reload_config = False
-        try:
-            with open(self._config_filename, "r") as f:
-                config_script = f.read()
-        except (IOError, OSError):  # pragma: no cover
-            logging.exception("Could not read config file %s",
-                              self._config_filename)
-            return False
-
-        # The environment in which the configuration script is executed (and
-        # where the script will store its options.)
-        try:
-            g = {}
-            g.update(configuration.__dict__)
-            g.update(coordinates.__dict__)
-            exec(config_script, g)
-        except:
-            # Executing the config file failed, don't update any settings
-            logging.exception("Error while evaluating config file %s",
-                              self._config_filename)
-            return False
-
-        # Make sure a configuration object is specified
-        new = g.get("configuration", None)
-        if not isinstance(new, Configuration):
-            logging.error("'configuration' must be a Configuration object " +
-                          "in config file %s", self._config_filename)
-            return False
-
-        # Update the configuration
+    @overrides(super_class_method=ConfigurationReloader._load_valid_config)
+    def _load_valid_config(self, new):
         old = self._configuration
         self._configuration = new
 
         # Restart the server if the port or IP has changed (or if the server
         # has not yet been started...)
-        if (new.ip != old.ip or
-                self._server_socket is None):
+        if new.ip != old.ip or self._server_socket is None:
             # Close all open connections
             if self._close():  # pragma: no cover
-                time.sleep(0.25)  # Ugly hack; fully release socket now
+                sleep(0.25)  # Ugly hack; fully release socket now
 
             # Create a new server socket
-            self._open(new.ip)
+            self._open_server_socket(new.ip, self._port)
 
         # Update the controller
         self._controller.max_retired_jobs = new.max_retired_jobs
-        self._controller.machines = OrderedDict((m.name, m)
-                                                for m in new.machines)
-
-        logging.info("Config file %s read successfully.",
-                     self._config_filename)
-        return True
-
-    def _open(self, ipaddress):
-        """Create a new server socket.
-
-        :param str ipaddress: The local address of the socket.
-        """
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((ipaddress, self._port))
-        sock.listen(5)
-        self.register_channel(sock)
-        self._server_socket = sock
+        self._controller.machines = OrderedDict(
+            (m.name, m) for m in new.machines)
 
     def _close(self):
         """Close all server sockets and disconnect all client connections."""
@@ -369,9 +220,9 @@ class Server(PollingServerCore):
         client : :py:class:`socket.Socket`
         """
         try:
-            logging.info("Client %s disconnected.", client.getpeername())
+            log.info("Client %s disconnected.", client.getpeername())
         except:
-            logging.info("Client %s disconnected.", client)
+            log.info("Client %s disconnected.", client)
 
         # Clear input buffer
         del self._client_buffers[client]
@@ -391,9 +242,9 @@ class Server(PollingServerCore):
         try:
             client, addr = self._server_socket.accept()
         except IOError as e:  # pragma: no cover
-            logging.warn("problem when accepting connection", exc_info=e)
+            log.warn("problem when accepting connection", exc_info=e)
             return
-        logging.info("New client connected from %s", addr)
+        log.info("New client connected from %s", addr)
 
         # Watch the client's socket for data
         self.register_channel(client)
@@ -412,7 +263,7 @@ class Server(PollingServerCore):
             The object or array to send. Will be converted to JSON.
         """
         try:
-            client.send(json.dumps(message).encode("utf-8") + b"\n")
+            client.send(json(message).encode("utf-8") + b"\n")
         except:
             self._disconnect_client(client)
             raise
@@ -429,19 +280,19 @@ class Server(PollingServerCore):
             The line parsed from the socket. Should be a complete JSON object
             with at least a 'command' key.
         """
-        cmd_obj = json.loads(line.decode("utf-8"))
+        cmd_obj = dejson(line.decode("utf-8"))
         if "command" not in cmd_obj:
             raise IOError("no command name given")
         commandName = cmd_obj["command"]
         if not isinstance(commandName, string_types):
             raise IOError("parsed gibberish from user")
         if commandName not in _COMMANDS:
-            logging.info("lookup failure: %s", commandName)
+            log.info("lookup failure: %s", commandName)
             raise IOError("unrecognised command name")
         command = _COMMANDS[commandName]
         if command is None:  # pragma: no cover
             # Should be unreachable
-            logging.critical("unexpected lookup failure: %s", commandName)
+            log.critical("unexpected lookup failure: %s", commandName)
             raise IOError("unrecognised command name")
         args = cmd_obj["args"] if "args" in cmd_obj else []
         if not isinstance(args, list):
@@ -488,8 +339,8 @@ class Server(PollingServerCore):
             # If any of the above fails for any reason (e.g. invalid JSON,
             # unrecognised command, command crashes, etc.), just disconnect
             # the client.
-            logging.exception("Client %s sent bad command %r, disconnecting",
-                              peer, line)
+            log.exception("Client %s sent bad command %r, disconnecting",
+                          peer, line)
             self._disconnect_client(client)
 
     def _send_notifications(self, label, changes, watches):
@@ -502,7 +353,7 @@ class Server(PollingServerCore):
                             label: list(changes) if items is None else
                             list(changes.intersection(items))})
                     except (OSError, IOError):
-                        logging.exception("Could not send notification.")
+                        log.exception("Could not send notification.")
 
     def _send_change_notifications(self):
         """Send any registered change notifications to clients.
@@ -530,7 +381,7 @@ class Server(PollingServerCore):
         :py:meth:`.controller.Controller.destroy_timed_out_jobs` on the
         controller.
         """
-        logging.info("Server running.")
+        log.info("Server running.")
         while not self._stop:
             # Wait for a connection to get opened/closed, a command to arrive,
             # the config file to change or the timeout to elapse.
@@ -554,9 +405,9 @@ class Server(PollingServerCore):
             self._send_change_notifications()
 
             # Config file changed, re-read it
-            if self._reload_config:
-                if not self._read_config_file():  # pragma: no cover
-                    logging.warning("failed to reread configuration file")
+            if self.config_needs_reloading:
+                if not self.read_config_file():  # pragma: no cover
+                    log.warning("failed to reread configuration file")
 
     def is_alive(self):
         """Is the server running?"""
@@ -569,7 +420,7 @@ class Server(PollingServerCore):
 
     def stop_and_join(self):
         """Stop the server and wait for it to shut down completely."""
-        logging.info("Server shutting down, please wait...")
+        log.info("Server shutting down, please wait...")
 
         # Shut down server thread
         self._stop = True
@@ -577,24 +428,26 @@ class Server(PollingServerCore):
         self._server_thread.join()
 
         # Close all connections
-        logging.info("Closing connections...")
+        log.info("Closing connections...")
         self._close()
 
         # Shut down the controller and flush all BMP commands
-        logging.info("Waiting for all queued BMP commands...")
+        log.info("Waiting for all queued BMP commands...")
         self._controller.stop()
         self._controller.join()
 
         # Dump controller state to file
         with open(self._state_filename, "wb") as f:
-            pickle.dump(self._controller, f)
+            pickle(self._controller, f)
 
-        logging.info("Server shut down.")
+        log.info("Server shut down.")
 
         self._running = False
 
+
+class SpallocServer(Server):
     @spalloc_command
-    def version(self, client):
+    def version(self, client):  # @UnusedVariable
         """
         Returns
         -------
@@ -603,7 +456,7 @@ class Server(PollingServerCore):
         return __version__
 
     @spalloc_command
-    def create_job(self, client, *args, **kwargs):
+    def create_job(self, client, *args, **kwargs):  # @UnusedVariable
         """Create a new job (i.e. allocation of boards).
 
         This function should be called in one of the following styles::
@@ -705,7 +558,7 @@ class Server(PollingServerCore):
         return self._controller.create_job(*args, **kwargs)
 
     @spalloc_command
-    def job_keepalive(self, client, job_id):
+    def job_keepalive(self, client, job_id):  # @UnusedVariable
         """Reset the keepalive timer for the specified job.
 
         Note all other job-specific commands implicitly do this.
@@ -718,7 +571,7 @@ class Server(PollingServerCore):
         self._controller.job_keepalive(job_id)
 
     @spalloc_command
-    def get_job_state(self, client, job_id):
+    def get_job_state(self, client, job_id):  # @UnusedVariable
         """Poll the state of a running job.
 
         Parameters
@@ -755,7 +608,7 @@ class Server(PollingServerCore):
         return out
 
     @spalloc_command
-    def get_job_machine_info(self, client, job_id):
+    def get_job_machine_info(self, client, job_id):  # @UnusedVariable
         """Get the list of Ethernet connections to the allocated machine.
 
         Parameters
@@ -800,7 +653,7 @@ class Server(PollingServerCore):
                 "boards": boards}
 
     @spalloc_command
-    def power_on_job_boards(self, client, job_id):
+    def power_on_job_boards(self, client, job_id):  # @UnusedVariable
         """Power on (or reset if already on) boards associated with a job.
 
         Once called, the job will enter the 'power' state until the power state
@@ -814,7 +667,7 @@ class Server(PollingServerCore):
         self._controller.power_on_job_boards(job_id)
 
     @spalloc_command
-    def power_off_job_boards(self, client, job_id):
+    def power_off_job_boards(self, client, job_id):  # @UnusedVariable
         """Power off boards associated with a job.
 
         Once called, the job will enter the 'power' state until the power state
@@ -828,7 +681,7 @@ class Server(PollingServerCore):
         self._controller.power_off_job_boards(job_id)
 
     @spalloc_command
-    def destroy_job(self, client, job_id, reason=None):
+    def destroy_job(self, client, job_id, reason=None):  # @UnusedVariable
         """Destroy a job.
 
         Call when the job is finished, or to terminate it early, this function
@@ -970,7 +823,7 @@ class Server(PollingServerCore):
                                            machine_name)
 
     @spalloc_command
-    def list_jobs(self, client):
+    def list_jobs(self, client):  # @UnusedVariable
         """Enumerate all non-destroyed jobs.
 
         Returns
@@ -1019,7 +872,7 @@ class Server(PollingServerCore):
         return out
 
     @spalloc_command
-    def list_machines(self, client):
+    def list_machines(self, client):  # @UnusedVariable
         """Enumerates all machines known to the system.
 
         Returns
@@ -1055,7 +908,8 @@ class Server(PollingServerCore):
         return out
 
     @spalloc_command
-    def get_board_position(self, client, machine_name, x, y, z):
+    def get_board_position(self, client,  # @UnusedVariable
+                           machine_name, x, y, z):
         """Get the physical location of a specified board.
 
         Parameters
@@ -1074,7 +928,8 @@ class Server(PollingServerCore):
         return self._controller.get_board_position(machine_name, x, y, z)
 
     @spalloc_command
-    def get_board_at_position(self, client, machine_name, x, y, z):
+    def get_board_at_position(self, client,  # @UnusedVariable
+                              machine_name, x, y, z):
         """Get the logical location of a board at the specified physical
         location.
 
@@ -1094,7 +949,7 @@ class Server(PollingServerCore):
         return self._controller.get_board_at_position(machine_name, x, y, z)
 
     @spalloc_command
-    def where_is(self, client, **kwargs):
+    def where_is(self, client, **kwargs):  # @UnusedVariable
         """Find out where a SpiNNaker board or chip is located, logically and
         physically.
 
@@ -1161,7 +1016,7 @@ def main(args=None):
     args : [arg, ...], optional
         The command-line arguments passed to the program.
     """
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description="Start a SpiNNaker machine partitioning server.")
     parser.add_argument("--version", "-V", action="version",
                         version="%(prog)s {}".format(__version__))
@@ -1178,17 +1033,17 @@ def main(args=None):
     args = parser.parse_args(args)
 
     if not args.quiet:
-        logging.basicConfig(level=logging.INFO)
+        log.basicConfig(level=log.INFO)
 
-    server = Server(config_filename=args.config,
-                    cold_start=args.cold_start, port=args.port)
+    server = SpallocServer(config_filename=args.config,
+                           cold_start=args.cold_start, port=args.port)
     try:
         # NB: Originally this loop was replaced with a call to server.join
         # however in Python 2, such blocking calls are not interruptible so we
         # use this rather ugly workaround instead.
         while server.is_alive():  # pragma: no cover
             try:
-                time.sleep(0.1)
+                sleep(0.1)
             except IOError:
                 pass
     except KeyboardInterrupt:

--- a/tests/mock_bmp.py
+++ b/tests/mock_bmp.py
@@ -1,12 +1,8 @@
-from spinnman.messages.sdp.sdp_message import SDPMessage
-from spinnman.messages.scp.scp_request_header import SCPRequestHeader
-from spinnman.messages.scp.enums.scp_result import SCPResult
-from spinnman.messages.sdp.sdp_header import SDPHeader
-from spinnman.messages.sdp.sdp_flag import SDPFlag
-from spinnman.connections.udp_packet_connections import udp_utils
-from spinnman.connections.udp_packet_connections.udp_connection \
-    import UDPConnection
-from spinnman import constants
+from spinnman.messages.sdp import SDPMessage, SDPHeader, SDPFlag
+from spinnman.messages.scp import SCPRequestHeader
+from spinnman.messages.scp.enums import SCPResult
+from spinnman.connections.udp_packet_connections import utils, UDPConnection
+from spinnman.constants import SCP_SCAMP_PORT
 
 from collections import deque
 from threading import Thread
@@ -22,7 +18,7 @@ class SCPOKMessage(SDPMessage):
         sdp_header = SDPHeader(
             flags=SDPFlag.REPLY_NOT_EXPECTED, destination_port=0,
             destination_cpu=0, destination_chip_x=x, destination_chip_y=y)
-        udp_utils.update_sdp_header_for_udp_send(sdp_header, 0, 0)
+        utils.update_sdp_header_for_udp_send(sdp_header, 0, 0)
         SDPMessage.__init__(self, sdp_header, data=scp_header.bytestring)
 
 
@@ -37,7 +33,7 @@ class SCPVerMessage(SDPMessage):
         sdp_header = SDPHeader(
             flags=SDPFlag.REPLY_NOT_EXPECTED, destination_port=0,
             destination_cpu=0, destination_chip_x=x, destination_chip_y=y)
-        udp_utils.update_sdp_header_for_udp_send(sdp_header, 0, 0)
+        utils.update_sdp_header_for_udp_send(sdp_header, 0, 0)
         SDPMessage.__init__(self, sdp_header)
 
     def set_sequence(self, sequence):
@@ -69,7 +65,7 @@ class MockBMP(Thread):
         Thread.__init__(self, verbose=True)
 
         # Set up a connection to be the machine
-        self._receiver = UDPConnection(local_port=constants.SCP_SCAMP_PORT)
+        self._receiver = UDPConnection(local_port=SCP_SCAMP_PORT)
         self._running = False
         self._error = None
         self._responses = deque()

--- a/tests/mock_bmp.py
+++ b/tests/mock_bmp.py
@@ -12,7 +12,7 @@ import traceback
 
 class SCPOKMessage(SDPMessage):
 
-    def __init__(self, x, y, sequence=0):
+    def __init__(self, x, y, sequence=0):  # pragma: no cover
         scp_header = SCPRequestHeader(
             command=SCPResult.RC_OK, sequence=sequence)
         sdp_header = SDPHeader(
@@ -73,11 +73,11 @@ class MockBMP(Thread):
             self._responses.extend(responses)
 
     @property
-    def error(self):
+    def error(self):  # pragma: no cover
         return self._error
 
     @property
-    def local_port(self):
+    def local_port(self):  # pragma: no cover
         return self._receiver.local_port
 
     def run(self):
@@ -91,7 +91,7 @@ class MockBMP(Thread):
                     response = None
                     if len(self._responses) > 0:
                         response = self._responses.popleft()
-                    else:
+                    else:  # pragma: no cover
                         response = SCPOKMessage(
                             sdp_header.source_chip_x, sdp_header.source_chip_y,
                             sequence)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,7 +63,7 @@ class SimpleClient(SimpleClientSocket):
     def recv_line(self, length=1024):
         while b"\n" not in self.buf:
             data = self.sock.recv(length)
-            if not data:
+            if not data:  # pragma: no cover
                 raise DisconnectedException("Socket disconnected!")
             self.buf += data
         line, _, self.buf = self.buf.partition(b"\n")
@@ -85,7 +85,7 @@ class SimpleClient(SimpleClientSocket):
                 raise
             if "return" in resp:
                 return resp["return"]
-            else:
+            else:  # pragma: no cover
                 self.notifications.append(resp)
 
     def call(self, cmd, *args, **kwargs):
@@ -93,7 +93,7 @@ class SimpleClient(SimpleClientSocket):
         return self.get_return()
 
     def get_notification(self):
-        if self.notifications:
+        if self.notifications:  # pragma: no cover
             return self.notifications.pop(0)
         else:
             line = self.recv_line()
@@ -127,13 +127,14 @@ class EvilClient(SimpleClientSocket):
                 raise
             if "return" in resp:
                 return resp["return"]
-            self.notifications.append(resp)
+            else:  # pragma: no cover
+                self.notifications.append(resp)
 
     def call(self, call):
         self.sock.send(call.replace("'", "\"").encode("utf-8") + b"\n")
         return self.get_return()
 
-    def get_notification(self):
+    def get_notification(self):  # pragma: no cover
         if self.notifications:
             return self.notifications.pop(0)
         line = self._recv_line()
@@ -408,7 +409,7 @@ def test_read_config_file(simple_config, s):
 
 @pytest.mark.timeout(1.0)
 def test_reread_config_file(simple_config, s):
-    if not hasattr(signal, "SIGHUP"):
+    if not hasattr(signal, "SIGHUP"):  # pragma: no cover
         return
 
     # Make sure config re-reading works
@@ -767,7 +768,7 @@ def test_machine_notifications(double_config, s):
             assert c1.get_notification() == {"machines_changed": ["m1"]}
 
             # Make sure machine changes get announced
-            if not hasattr(signal, "SIGHUP"):
+            if not hasattr(signal, "SIGHUP"):  # pragma: no cover
                 return
             with open(double_config, "w") as f:
                 f.write("configuration = {}".format(repr(Configuration())))


### PR DESCRIPTION
This PR reworks the server part of Spalloc into four pieces:

1. Core network handling. (`polling_server_core.py`)
2. Configuration loader and `SIGHUP` signal handler. (`configuration_reloader.py`)
3. The spalloc wire protocol encoding and dispatch. (`Server` in `server.py`)
4. The spalloc high-level protocol definition (`SpallocServer` in `server.py`)

Parts 3 and 4 are together because they share a bit of method registration code, which couples them a bit more than usual.