### PR TITLE
Added logging of major job actions.

### DIFF
--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from enum import IntEnum
 from functools import partial
 import logging
+from logging.handlers import TimedRotatingFileHandler
 from pytz import utc
 import threading
 import time
@@ -21,7 +22,7 @@ from spinn_machine.spinnaker_triad_geometry import SpiNNakerTriadGeometry
 
 job_log = logging.Logger("jobs")
 job_log.propagate = False
-job_log.addHandler(logging.handlers.TimedRotatingFileHandler(
+job_log.addHandler(TimedRotatingFileHandler(
     "spalloc_jobs.log", when="D"))
 
 


### PR DESCRIPTION
This logs:
* Creation (including all arguments)
* Destruction (including reason if present)
* Changes of power status of boards

The log is written to `spalloc_jobs.log` in the current directory, with a daily file rollover (as this is production information logging).

We might wish to look at [other ways to configure logging](https://docs.python.org/2/howto/logging.html); if we do this, the log I'm using is called `jobs` inside the Python logging system.