### PR TITLE
More logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
         - 2.7
         # Remove 3.5 because SpiNNMan isn't Py3-compatible yet
         # - 3.5
+virtualenv:
+        system_site_packages: true
+cache: pip
+
 before_install:
         - pip install --upgrade pip setuptools wheel
         - pip install --upgrade git+git://github.com/SpiNNakerManchester/SpiNNUtils.git@${TRAVIS_BRANCH} || pip install --upgrade git+git://github.com/SpiNNakerManchester/SpiNNUtils.git@master
@@ -15,17 +19,13 @@ install:
         - pip install -r requirements-test.txt
         - pip install python-coveralls
 script:
-        - >
-            py.test tests/ \
-                    --cov spalloc_server \
-                    --cov tests \
-                    --durations=10
+        - py.test tests/ --cov spalloc_server --cov tests --durations=10
         # Code quality check
         - flake8
 after_success:
         - coveralls
+
 notifications:
         email: false
-
 matrix:
-    fast_finish: true
+        fast_finish: true

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -524,6 +524,8 @@ class Controller(object):
             A human-readable string describing the reason for the
             job's destruction.
         """
+        if clienthost is None:
+            clienthost = "internal"
         if reason is None:
             job_log.info("destroy_job(%s) from %s", job_id, clienthost)
         else:
@@ -946,7 +948,7 @@ class Controller(object):
             for job in list(itervalues(self._jobs)):
                 if job.keepalive is not None and job.keepalive_until < now:
                     # Job timed out, destroy it
-                    self.destroy_job(job.id, "Job timed out.")
+                    self.destroy_job(None, job.id, "Job timed out.")
 
     def _bmp_on_request_complete(self, job, success):
         """Callback function called by an AsyncBMPController when it completes
@@ -969,7 +971,8 @@ class Controller(object):
         with self._lock:
             # If a BMP command failed, cancel the job
             if not success:
-                self.destroy_job(job.id, "Machine configuration failed, " +
+                self.destroy_job(None, job.id,
+                                 "Machine configuration failed, "
                                  "please try again later.")
 
             # Count down the number of outstanding requests before the job is

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -443,7 +443,7 @@ class Server(PollingServerCore, ConfigurationReloader):
         """
         try:
             return None if client is None else str(client.getpeername()[0])
-        except:
+        except:  # pragma: no cover
             return None
 
 

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -591,8 +591,7 @@ class SpallocServer(Server):
         kwargs["owner"] = str(owner)
         keepalive = kwargs.get("keepalive", 60.0)
         kwargs["keepalive"] = (None if keepalive is None else float(keepalive))
-        ownerhost = self._name(client)
-        return self._controller.create_job(ownerhost, *args, **kwargs)
+        return self._controller.create_job(self._name(client), *args, **kwargs)
 
     @spalloc_command
     def job_keepalive(self, client, job_id):  # @UnusedVariable
@@ -605,8 +604,7 @@ class SpallocServer(Server):
         job_id : int
             A job ID to be kept alive.
         """
-        alivehost = self._name(client)
-        self._controller.job_keepalive(alivehost, job_id)
+        self._controller.job_keepalive(self._name(client), job_id)
 
     @spalloc_command
     def get_job_state(self, client, job_id):  # @UnusedVariable
@@ -641,8 +639,8 @@ class SpallocServer(Server):
                 For queued and allocated jobs, gives the Unix time (UTC) at
                 which the job was created (or None otherwise).
         """
-        alivehost = self._name(client)
-        out = self._controller.get_job_state(alivehost, job_id)._asdict()
+        out = self._controller.get_job_state(
+            self._name(client), job_id)._asdict()
         out["state"] = int(out["state"])
         return out
 
@@ -678,9 +676,8 @@ class SpallocServer(Server):
                 All the boards allocated to the job or None if no boards
                 allocated.
         """
-        alivehost = self._name(client)
         width, height, connections, machine_name, boards = \
-            self._controller.get_job_machine_info(alivehost, job_id)
+            self._controller.get_job_machine_info(self._name(client), job_id)
 
         if connections is not None:
             connections = list(iteritems(connections))
@@ -704,8 +701,7 @@ class SpallocServer(Server):
         job_id : int
             A job ID to turn boards on for.
         """
-        alivehost = self._name(client)
-        self._controller.power_on_job_boards(alivehost, job_id)
+        self._controller.power_on_job_boards(self._name(client), job_id)
 
     @spalloc_command
     def power_off_job_boards(self, client, job_id):  # @UnusedVariable
@@ -719,8 +715,7 @@ class SpallocServer(Server):
         job_id : int
             A job ID to turn boards off for.
         """
-        alivehost = self._name(client)
-        self._controller.power_off_job_boards(alivehost, job_id)
+        self._controller.power_off_job_boards(self._name(client), job_id)
 
     @spalloc_command
     def destroy_job(self, client, job_id, reason=None):  # @UnusedVariable
@@ -738,8 +733,7 @@ class SpallocServer(Server):
             A human-readable string describing the reason for the job's
             destruction.
         """
-        killerhost = self._name(client)
-        self._controller.destroy_job(killerhost, job_id, reason)
+        self._controller.destroy_job(self._name(client), job_id, reason)
 
     def _register_for_notifications(self, client, watchset,
                                     id):  # @ReservedAssignment

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -641,6 +641,9 @@ def test_job_management(simple_config, s, c):
     assert jobs[0]["boards"] == [[0, 0, 0]]
     assert jobs[1]["boards"] is None
 
+    assert jobs[0]["keepalivehost"] == "127.0.0.1"
+    assert jobs[1]["keepalivehost"] == "127.0.0.1"
+
     # Destroying jobs should work
     c.call("destroy_job", job_id0, "Test reason...")
     time.sleep(0.05)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -574,15 +574,17 @@ def test_job_management(simple_config, s, c):
     # State should be visible
     assert c.call("get_job_state", job_id0) == {
         "state": JobState.ready, "power": True,
-        "keepalive": 60.0, "reason": None, "start_time": 1234.5}
+        "keepalive": 60.0, "reason": None, "start_time": 1234.5,
+        "keepalivehost": "127.0.0.1"}
     assert c.call("get_job_state", job_id1) == {
         "state": JobState.queued, "power": None,
-        "keepalive": 60.0, "reason": None, "start_time": 5432.0}
+        "keepalive": 60.0, "reason": None, "start_time": 5432.0,
+        "keepalivehost": "127.0.0.1"}
     assert c.call("get_job_state", job_id2) == {
         "state": JobState.destroyed,  "power": None,
         "keepalive": None,
         "reason": "Cancelled: No suitable machines available.",
-        "start_time": None}
+        "start_time": None, "keepalivehost": None}
 
     # Ethernet connections should be visible, where defined
     assert c.call("get_job_machine_info", job_id0) == {
@@ -646,11 +648,13 @@ def test_job_management(simple_config, s, c):
         "state": JobState.destroyed, "power": None,
         "keepalive": None,
         "reason": "Test reason...",
-        "start_time": None}
+        "start_time": None,
+        "keepalivehost": None}
     assert c.call("get_job_state", job_id1) == {
         "state": JobState.ready, "power": True,
         "keepalive": 60.0, "reason": None,
-        "start_time": 5432.0}
+        "start_time": 5432.0,
+        "keepalivehost": "127.0.0.1"}
 
 
 @pytest.mark.timeout(2.0)
@@ -659,11 +663,13 @@ def test_keepalive_expiration(fast_keepalive_config, s, c):
 
     # Should be alive for a bit
     time.sleep(0.05)
-    assert s._controller.get_job_state(job_id).state != JobState.destroyed
+    assert s._controller.get_job_state(
+        None, job_id).state != JobState.destroyed
 
     # Should get killed
     time.sleep(0.35)
-    assert s._controller.get_job_state(job_id).state == JobState.destroyed
+    assert s._controller.get_job_state(
+        None, job_id).state == JobState.destroyed
 
 
 @pytest.mark.timeout(1.0)


### PR DESCRIPTION
This is the fix for https://github.com/SpiNNakerManchester/spalloc_server/issues/1


This adds tracking of the IP address that last did an action that triggered an update of the keep-alive timeout. The information is used in certain parts of logging and is also reported back in the result of `list_jobs()` as an extra field of the per-job tuple (`keepalivehost`).
