### PR TITLE
When the BMP calls fail, give better error messages to the user

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -931,7 +931,7 @@ def test_bmp_on_request_complete(MockABC, conn, m,
                     None, job_id).state == JobState.unknown
             else:
                 assert conn.get_job_state(None, job_id).state == mid_state
-            conn._bmp_on_request_complete(job, success)
+            conn._bmp_on_request_complete(job, "mock", success)
 
         assert conn.get_job_state(None, job_id).state == end_state
 


### PR DESCRIPTION
Christian was being mystified by failures overnight from spalloc, as they were distinctly “Computer Says No” in flavour (though narrowable down to _something_ going wrong while issuing BMP commands). This makes the error a bit more informative, though the information that spalloc hands out is still quite limited.