### PR TITLE
Reorder timeout

### DIFF
--- a/spalloc_server/polling_server_core.py
+++ b/spalloc_server/polling_server_core.py
@@ -78,7 +78,7 @@ class PollingServerCore(object):
                  :py:meth:`.wake` call.
         """
         if self._poll is not None:
-            events = self._poll.poll(timeout_check_interval)
+            events = self._poll.poll(timeout_check_interval * 1000.0)
             for fd, _ in events:
                 if fd == self._notify_recv.fileno():
                     self._notify_recv.recv(BUFFER_SIZE)

--- a/spalloc_server/polling_server_core.py
+++ b/spalloc_server/polling_server_core.py
@@ -32,6 +32,9 @@ class PollingServerCore(object):
     """Wrapper around the operating system's poll() call. Also knows the\
     basics of making sockets.
     """
+
+    MILLISECOND_TO_SECOND_CONVERTER = 1000.0
+
     def __init__(self):
         # The poll object used for listening for connections
         self._poll = None
@@ -78,7 +81,8 @@ class PollingServerCore(object):
                  :py:meth:`.wake` call.
         """
         if self._poll is not None:
-            events = self._poll.poll(timeout_check_interval * 1000.0)
+            events = self._poll.poll(
+                timeout_check_interval * self.MILLISECOND_TO_SECOND_CONVERTER)
             for fd, _ in events:
                 if fd == self._notify_recv.fileno():
                     self._notify_recv.recv(BUFFER_SIZE)

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -381,9 +381,6 @@ class Server(PollingServerCore, ConfigurationReloader):
             channels = self.ready_channels(
                 self._configuration.timeout_check_interval)
 
-            # Cull any jobs which have timed out
-            self._controller.destroy_timed_out_jobs()
-
             for channel in channels:
                 if channel is None:  # pragma: no cover
                     continue
@@ -393,6 +390,9 @@ class Server(PollingServerCore, ConfigurationReloader):
                 else:
                     # Incoming data from client
                     self._handle_commands(channel)
+
+            # Cull any jobs which have timed out
+            self._controller.destroy_timed_out_jobs()
 
             # Send any job/machine change notifications out
             self._send_change_notifications()

--- a/tests/test_polling_server_core.py
+++ b/tests/test_polling_server_core.py
@@ -1,0 +1,17 @@
+from spalloc_server.polling_server_core import PollingServerCore
+import socket
+import time
+
+
+def test_ready_channels_timeout():
+    polling_server_core = PollingServerCore()
+    server_socket = polling_server_core._open_server_socket("localhost", 0)
+    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client_socket.connect(server_socket.getsockname())
+    client, _ = server_socket.accept()
+    polling_server_core.register_channel(client)
+    start_time = time.time()
+    channels = list(polling_server_core.ready_channels(1.0))
+    assert len(channels) == 0
+    end_time = time.time()
+    assert int(end_time - start_time) == 1


### PR DESCRIPTION
I'm not certain this will have a major effect on jobs, but just in case, this reorders so that the timeout of a job is done after the processing of commands.  This should allow a client to stop a job being destroyed just outside of the timeout.