### PR TITLE
Fpga check update

### DIFF
--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -190,8 +190,7 @@ class AsyncBMPController(object):
 
                 # check each FPGA on board
                 if not all(self._good_fpga(board, fpga)
-                           for fpga in range(_N_FPGAS)
-                           for board in boards):
+                           for fpga in range(_N_FPGAS)):
                     retry_boards.append(board)
 
             # try again with incorrect boards only

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -237,13 +237,13 @@ class AsyncBMPController(object):
         :param board: Which board or boards to set the link enable-state of.
         :type board: int or iterable
         """
-        # skip FPGA link configuration if old BMP version
-        vi = self._transceiver.read_bmp_version(board=board,
-                                                frame=0, cabinet=0)
-        if vi.version_number[0] < _BMP_VER_MIN:
-            return True, None
-
         try:
+            # skip FPGA link configuration if old BMP version
+            vi = self._transceiver.read_bmp_version(board=board,
+                                                frame=0, cabinet=0)
+            if vi.version_number[0] < _BMP_VER_MIN:
+                return True, None
+
             fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
             self._transceiver.write_fpga_register(
                 fpga, addr, int(not enable), board=board, frame=0, cabinet=0)

--- a/tests/test_async_bmp_controller.py
+++ b/tests/test_async_bmp_controller.py
@@ -8,7 +8,6 @@ from spalloc_server.async_bmp_controller import AsyncBMPController
 from spalloc_server.links import Links
 from mock_bmp import MockBMP
 from mock_bmp import SCPVerMessage
-from spinnman.model.version_info import VersionInfo
 
 
 @pytest.yield_fixture

--- a/tests/test_async_bmp_controller.py
+++ b/tests/test_async_bmp_controller.py
@@ -8,6 +8,7 @@ from spalloc_server.async_bmp_controller import AsyncBMPController
 from spalloc_server.links import Links
 from mock_bmp import MockBMP
 from mock_bmp import SCPVerMessage
+from spinnman.model.version_info import VersionInfo
 
 
 @pytest.yield_fixture
@@ -94,6 +95,19 @@ def mock_read_fpga_register(fpga_num, register, board, cabinet, frame):
     return fpga_num
 
 
+class MockVersionNumber(object):
+    def __init__(self, version):
+        self._version = version
+
+    @property
+    def version_number(self):
+        return self._version
+
+
+def mock_read_bmp_version(board, frame, cabinet):
+    return MockVersionNumber((2, 0, 0))
+
+
 @pytest.mark.timeout(1.0)
 @pytest.mark.parametrize("power_side_effect,success",
                          [(None, True),
@@ -115,6 +129,7 @@ def test_set_power(abc, bc, power_side_effect, success):
     bc.power_on.side_effect = power_side_effect
     bc.power_off.side_effect = power_side_effect
     bc.read_fpga_register.side_effect = mock_read_fpga_register
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
     e.wait()
     assert e.success is success
     bc.power_on.assert_called_once_with(boards=[11], frame=0, cabinet=0)
@@ -205,6 +220,7 @@ def test_set_link_enable(abc, bc, link, fpga, addr, enable, value,
     # Make sure that the set link command works (and failure is reported)
     e = OnDoneEvent()
     bc.write_fpga_register.side_effect = side_effect
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
     abc.set_link_enable(10, link, enable, e)
     e.wait()
     assert e.success is success
@@ -218,6 +234,7 @@ def test_set_link_enable_blocks(abc, bc):
     # Make sure that the set power command can block
     event = threading.Event()
     bc.write_fpga_register.side_effect = (lambda *a, **k: event.wait())
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
 
     done_event = OnDoneEvent()
     abc.set_link_enable(10, Links.east, True, done_event)
@@ -244,6 +261,7 @@ def test_power_priority(abc, bc):
     bc.power_on.side_effect = (lambda *a, **k: power_on_event.wait(1.0))
     bc.power_off.side_effect = (lambda *a, **k: power_off_event.wait(1.0))
     bc.write_fpga_register.side_effect = (lambda *a, **k: link_event.wait(1.0))
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
 
     with abc:
         e1, e2, e3 = (OnDoneEvent() for _ in range(3))
@@ -298,6 +316,7 @@ def test_power_removes_link_enables(abc, bc):
     # Make sure link enable requests are removed for boards with newly added
     # power commands.
     bc.read_fpga_register.side_effect = mock_read_fpga_register
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
     with abc:
         e1, e2, e3, e4 = (OnDoneEvent() for _ in range(4))
         abc.set_power(10, True, e1)
@@ -333,6 +352,7 @@ def test_stop_drains(abc, bc):
     # processed
     set_power_done = OnDoneEvent()
     set_link_enable_done = OnDoneEvent()
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
     with abc:
         abc.set_power(10, False, set_power_done)
         abc.set_link_enable(11, Links.east, False, set_link_enable_done)


### PR DESCRIPTION
- Check that BMP firmware version supports FPGA register management before doing any operations that require it.
- FPGA bitmap check after a set of boards is powered up now results in power cycling incorrect boards only.
