### PR TITLE
No jumping requests

### DIFF
--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -327,7 +327,9 @@ class AsyncBMPController(object):
                 state = self._requests[0].state
                 boards = list()
                 on_done = []
-                while self._requests and self._requests[0].state == state:
+                while (self._requests and
+                       isinstance(self._requests[0], _PowerRequest) and
+                       self._requests[0].state == state):
                     request = self._requests.popleft()
                     boards.append(request.board)
                     on_done.append(request.on_done)

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -338,6 +338,10 @@ class AsyncBMPController(object):
             # Otherwise return just the next request
             return self._requests.popleft()
 
+    @property
+    def hostname(self):
+        return self._hostname
+
 
 class _PowerRequest(namedtuple("_PowerRequest", "state board on_done")):
     """ Requests that a specific board should have its power state set to a

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -11,13 +11,16 @@ from spinnman.model import BMPConnectionData
 from spinnman.constants import SCP_SCAMP_PORT
 
 from .links import Links
+import time
 
 # The first BMP version with FPGA register support
 _BMP_VER_MIN = 2
 
 _N_FPGA_RETRIES = 3
 
-_N_REQUEST_TRIES = 1
+_N_REQUEST_TRIES = 2
+
+_SECONDS_BETWEEN_TRIES = 15
 
 
 class AsyncBMPController(object):
@@ -209,13 +212,17 @@ class AsyncBMPController(object):
                             break
                         except Exception as e:
                             if (n_tries + 1) == _N_REQUEST_TRIES:
-                                reason = "Request failed on BMP {}".format(
+                                reason = "Requests failed on BMP {}".format(
                                     self._hostname)
                                 logging.exception(reason + ": " + str(e))
                                 request.on_done(False, reason)
                                 break
-                            logging.exception("Retrying request on BMP {}: {}"
-                                              .format(self._hostname, str(e)))
+                            logging.exception(
+                                "Retrying requests on BMP {} after {}"
+                                " seconds: {}".format(
+                                    self._hostname, _SECONDS_BETWEEN_TRIES,
+                                    str(e)))
+                            time.sleep(_SECONDS_BETWEEN_TRIES)
 
                 # If nothing left in the queues, clear the request flag and
                 # break out of queue-processing loop.

--- a/spalloc_server/async_bmp_controller.py
+++ b/spalloc_server/async_bmp_controller.py
@@ -17,6 +17,8 @@ _BMP_VER_MIN = 2
 
 _N_FPGA_RETRIES = 3
 
+_N_REQUEST_TRIES = 1
+
 
 class AsyncBMPController(object):
     """ An object which provides an asynchronous interface to a power and link
@@ -84,66 +86,12 @@ class AsyncBMPController(object):
         self._lock.release()
         return False
 
-    def set_power(self, board, state, on_done):
-        """ Set the power state of a single board.
-
-        Parameters
-        ----------
-        board : int
-            The board to control.
-        state : bool
-            True = on, False = off.
-        on_done : function(success)
-            Function to call when the command completes. May be called from
-            another thread. Success is a bool which is True if the command
-            completed successfully and False if it did not (or was cancelled).
+    def add_requests(self, atomic_requests):
+        """ Add an atomic request to be performed
         """
-        # Verify that our arguments are sane
-        board = int(board)
-        state = bool(state)
         with self._lock:
             assert not self._stop
-
-            # Enqueue the request
-            self._requests.append(_PowerRequest(state, board, on_done))
-            self._requests_pending.set()
-
-            # Cancel any existing link enable commands for this board
-            cancelled = []
-            for request in list(self._requests):
-                if (isinstance(request, _LinkRequest) and
-                        request.board == board):
-                    self._requests.remove(request)
-                    cancelled.append(request)
-
-        for request in cancelled:
-            request.on_done(False, "Cancelled")
-
-    def set_link_enable(self, board, link, enable, on_done):
-        """ Enable or disable a link.
-
-        Parameters
-        ----------
-        board : int
-            The board on which the link resides.
-        link : :py:class:`spalloc_server.links.Links`
-            The link to configure.
-        enable : bool
-            True = link enabled, False = link disabled.
-        on_done : function(success)
-            Function to call when the command completes. May be called from
-            another thread. Success is a bool which is True if the command
-            completed successfully and False if it did not (or was cancelled).
-        """
-        # Verify that our arguments are sane
-        board = int(board)
-        enable = bool(enable)
-        with self._lock:
-            assert not self._stop
-
-            # Enqueue the request
-            self._requests.append(
-                _LinkRequest(board, link, enable, on_done))
+            self._requests.append(atomic_requests)
             self._requests_pending.set()
 
     def stop(self):
@@ -170,7 +118,7 @@ class AsyncBMPController(object):
                 fpga, board, self._hostname, fpga_id & _FPGA_FLAG_ID_MASK)
         return ok
 
-    def _boot_board(self, boards):
+    def _power_on_and_check(self, boards):
         # FPGAs are checked after power on - assume incorrect to start
         boards_to_power = boards
         for _try in range(_N_FPGA_RETRIES):
@@ -203,31 +151,6 @@ class AsyncBMPController(object):
                 "Could not get correct FPGA ID after {} tries".format(
                     _N_FPGA_RETRIES))
 
-    def _set_board_state(self, state, board):
-        """ Set the power state of a board.
-
-        :param state: What to set the state to. True for on, False for off
-        :type state: bool
-        :param board: Which board or boards to set the state of
-        :type board: int or iterable
-        """
-        try:
-            # If powering on...
-            if state:
-                self._boot_board(board)
-            # If powering off...
-            else:
-                self._transceiver.power_off(boards=board, frame=0, cabinet=0)
-            return True, None
-        except Exception:
-            reason = \
-                "Failed to set board power on BMP {}, boards {}, state={}."\
-                .format(self._hostname, board, state)
-
-            # Communication issue with the machine, log it
-            logging.exception(reason)
-            return False, reason
-
     def _set_link_state(self, link, enable, board):
         """ Set the power state of a link.
 
@@ -238,24 +161,15 @@ class AsyncBMPController(object):
         :param board: Which board or boards to set the link enable-state of.
         :type board: int or iterable
         """
-        try:
-            # skip FPGA link configuration if old BMP version
-            vi = self._transceiver.read_bmp_version(
-                board=board, frame=0, cabinet=0)
-            if vi.version_number[0] < _BMP_VER_MIN:
-                return True, None
+        # skip FPGA link configuration if old BMP version
+        vi = self._transceiver.read_bmp_version(
+            board=board, frame=0, cabinet=0)
+        if vi.version_number[0] < _BMP_VER_MIN:
+            return
 
-            fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
-            self._transceiver.write_fpga_register(
-                fpga, addr, int(not enable), board=board, frame=0, cabinet=0)
-            return True, None
-        except Exception:
-            reason = "Failed to set link state on BMP {}, board {}, link {},"\
-                " enable={}.".format(self._hostname, board, link, enable)
-
-            # Communication issue with the machine, log it
-            logging.exception(reason)
-            return False, reason
+        fpga, addr = FPGA_LINK_STOP_REGISTERS[link]
+        self._transceiver.write_fpga_register(
+            fpga, addr, int(not enable), board=board, frame=0, cabinet=0)
 
     def _run(self):
         """ The background thread for interacting with the BMP.
@@ -267,25 +181,41 @@ class AsyncBMPController(object):
             while True:
                 self._requests_pending.wait()
 
-                request = self._get_atomic_request()
-                if request:
-                    if isinstance(request, _PowerRequest):
-                        # Send the power command
-                        success, reason = self._set_board_state(
-                            request.state, request.board)
+                if self._requests:
+                    request = self._requests.popleft()
 
-                        # Alert all waiting threads
-                        for on_done in request.on_done:
-                            on_done(success, reason)
+                    for n_tries in range(_N_REQUEST_TRIES):
+                        try:
+                            # Send any power on commands
+                            if request.power_on_boards:
+                                self._power_on_and_check(
+                                    request.power_on_boards)
 
-                    if isinstance(request, _LinkRequest):
-                        # Set the link state, as required
-                        success, reason = self._set_link_state(
-                            request.link, request.enable, request.board)
+                            # Process link requests next
+                            for link_request in request.link_requests:
+                                # Set the link state, as required
+                                self._set_link_state(
+                                    link_request.link, link_request.enable,
+                                    link_request.board)
 
-                        # Alert waiting thread
-                        request.on_done(success, reason)
-                    continue
+                            # Finally send any power off commands
+                            if request.power_off_boards:
+                                self._transceiver.power_off(
+                                    boards=request.power_off_boards,
+                                    frame=0, cabinet=0)
+
+                            # Exit the retry loop if the requests all worked
+                            request.on_done(True, None)
+                            break
+                        except Exception as e:
+                            if (n_tries + 1) == _N_REQUEST_TRIES:
+                                reason = "Request failed on BMP {}".format(
+                                    self._hostname)
+                                logging.exception(reason + ": " + str(e))
+                                request.on_done(False, reason)
+                                break
+                            logging.exception("Retrying request on BMP {}: {}"
+                                              .format(self._hostname, str(e)))
 
                 # If nothing left in the queues, clear the request flag and
                 # break out of queue-processing loop.
@@ -306,62 +236,56 @@ class AsyncBMPController(object):
                 self._stop = True
             raise
 
-    def _get_atomic_request(self):
-        """ Gets the next request or requests from the queue.
-            If the next outstanding request is a power request, return a \
-            _PowerRequest which combines as many of the requests at\
-            the head of the queue as possible.
-            If the next outstanding request is a link request, return it
-
-        :rtype: :py:class:`._PowerRequest`, :py:class:`._LinkRequest` or None
-        """
-        with self._lock:
-            # Special case: no requests
-            if not self._requests:
-                return None
-
-            # If the next request is a power request
-            if isinstance(self._requests[0], _PowerRequest):
-
-                # Accumulate as many boards as possible
-                state = self._requests[0].state
-                boards = list()
-                on_done = []
-                while (self._requests and
-                       isinstance(self._requests[0], _PowerRequest) and
-                       self._requests[0].state == state):
-                    request = self._requests.popleft()
-                    boards.append(request.board)
-                    on_done.append(request.on_done)
-                return _PowerRequest(state, boards, on_done)
-
-            # Otherwise return just the next request
-            return self._requests.popleft()
-
     @property
     def hostname(self):
         return self._hostname
 
 
-class _PowerRequest(namedtuple("_PowerRequest", "state board on_done")):
-    """ Requests that a specific board should have its power state set to a
-    particular value.
-
-    Parameters
-    ----------
-    state : bool
-        On (True) or off (False).
-    board : int
-        Board to change the state of
-    on_done : function(success)
-        A function to call when the request has been completed.
+class AtomicRequests(object):
+    """ A list of requests that need to be done atomically; these are carried
+        out in order of power on, link enable or disable, power off
     """
 
-    # Python 3.4 Workaround: https://bugs.python.org/issue24931
-    __slots__ = tuple()
+    __slots__ = [
+        "_on_done",
+        "_power_on_boards",
+        "_power_off_boards",
+        "_link_requests"
+    ]
+
+    def __init__(self, on_done):
+        self._on_done = on_done
+        self._power_on_boards = list()
+        self._power_off_boards = list()
+        self._link_requests = list()
+
+    def power(self, board, power):
+        if power:
+            self._power_on_boards.append(board)
+        else:
+            self._power_off_boards.append(board)
+
+    def link(self, board, link, enable):
+        self._link_requests.append(LinkRequest(board, link, enable))
+
+    @property
+    def on_done(self):
+        return self._on_done
+
+    @property
+    def power_on_boards(self):
+        return self._power_on_boards
+
+    @property
+    def power_off_boards(self):
+        return self._power_off_boards
+
+    @property
+    def link_requests(self):
+        return self._link_requests
 
 
-class _LinkRequest(namedtuple("_LinkRequest", "board link enable on_done")):
+class LinkRequest(namedtuple("LinkRequest", "board link enable")):
     """ Requests that a specific board should have its power state set to a
     particular value.
 
@@ -373,8 +297,6 @@ class _LinkRequest(namedtuple("_LinkRequest", "board link enable on_done")):
         The link whose state should be changed
     enable : bool
         State of the link: Enabled (True), disabled (False).
-    on_done : function(success)
-        A function to call when the request has been completed.
     """
 
     # Python 3.4 Workaround: https://bugs.python.org/issue24931

--- a/spalloc_server/controller.py
+++ b/spalloc_server/controller.py
@@ -1033,6 +1033,8 @@ class Controller(object):
             for xyz in job.boards:
                 c, f, b = machine.board_locations[xyz]
                 controller = controllers[(c, f)]
+                job_log.info("set_power(%s, %s) on BMP %s for job %s",
+                             b, power, controller.hostname, job.id)
                 frame_commands[controller].append(
                     partial(controller.set_power, b, power, on_done_b))
 
@@ -1042,6 +1044,9 @@ class Controller(object):
                 for x, y, z, link in job.periphery:
                     c, f, b = machine.board_locations[(x, y, z)]
                     controller = controllers[(c, f)]
+                    job_log.info(
+                        "set_link_enable(%s, %s, %s) on BMP %s for job %s",
+                        b, link, link_enable, controller.hostname, job.id)
                     frame_commands[controller].append(
                         partial(controller.set_link_enable,
                                 b, link, link_enable, on_done_l))

--- a/spalloc_server/job_queue.py
+++ b/spalloc_server/job_queue.py
@@ -443,8 +443,8 @@ class JobQueue(object):
             self.on_cancel(job.id, reason)
         else:
             # Job was allocated somewhere, deallocate it
-            job.machine.allocator.free(job.allocation_id)
             self.on_free(job.id, reason)
+            job.machine.allocator.free(job.allocation_id)
 
         self._process_queue()
 

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -343,10 +343,11 @@ class Server(PollingServerCore, ConfigurationReloader):
             self._disconnect_client(client)
             return
 
-        peer = client.getpeername()
-        self._client_buffers[client] += data
-
+        peer = "UNKNOWN"
         try:
+            peer = client.getpeername()
+            self._client_buffers[client] += data
+
             # Process any complete commands (whole lines)
             while b"\n" in self._client_buffers[client]:
                 line, _, self._client_buffers[client] = \

--- a/spalloc_server/server.py
+++ b/spalloc_server/server.py
@@ -238,15 +238,21 @@ class Server(PollingServerCore, ConfigurationReloader):
         except Exception:
             log.info("Client %s disconnected.", client)
 
-        # Clear input buffer
-        del self._client_buffers[client]
+        # Clear input buffer if created
+        if client in self._client_buffers:
+            del self._client_buffers[client]
 
         # Clear any watches
         self._client_job_watches.pop(client, None)
         self._client_machine_watches.pop(client, None)
 
         # Stop watching the client's socket for data
-        self.unregister_channel(client)
+        try:
+            self.unregister_channel(client)
+        except KeyError:
+            # The odd case of the unregistered client -
+            # this can be ignored as it wasn't registered anyway
+            pass
 
         # Disconnect the client
         client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,7 @@ def mock_abc(monkeypatch):  # pragma: no cover
             self._thread.start()
 
             # Protected only by the GIL...
-            self.set_power_calls = []
-            self.set_link_enable_calls = []
+            self.add_requests_calls = []
 
         def _run(self):
             """Background thread, just take things from the request queue and
@@ -81,19 +80,11 @@ def mock_abc(monkeypatch):  # pragma: no cover
         def __exit__(self, _type=None, _value=None, _traceback=None):
             self._lock.release()
 
-        def set_power(self, board, state, on_done):
-            self.set_power_calls.append((board, state, on_done))
+        def add_requests(self, requests):
+            self.add_requests_calls.append(requests)
             with self._lock:
                 assert not self._stop
-                self._request_queue.append(on_done)
-                self._event.set()
-
-        def set_link_enable(self, board, link, enable, on_done):
-            self.set_link_enable_calls.append((board, link, enable, on_done))
-            with self._lock:
-
-                assert not self._stop
-                self._request_queue.append(on_done)
+                self._request_queue.append(requests.on_done)
                 self._event.set()
 
         def stop(self):

--- a/tests/test_async_bmp_controller.py
+++ b/tests/test_async_bmp_controller.py
@@ -2,7 +2,8 @@ from .mocker import Mock, call
 import pytest
 import threading
 
-from spalloc_server.async_bmp_controller import AsyncBMPController
+from spalloc_server.async_bmp_controller import AsyncBMPController,\
+    AtomicRequests
 from spalloc_server.links import Links
 from .mock_bmp import MockBMP, SCPVerMessage
 
@@ -113,22 +114,26 @@ def test_set_power(abc, bc, power_side_effect, success):
     e = OnDoneEvent()
     bc.power_on.side_effect = power_side_effect
     bc.power_off.side_effect = power_side_effect
-    abc.set_power(10, False, e)
+    requests = AtomicRequests(e)
+    requests.power(10, False)
+    abc.add_requests(requests)
     e.wait()
     assert e.success is success
     assert len(bc.power_on.mock_calls) == 0
-    bc.power_off.assert_called_once_with(boards=[10], frame=0, cabinet=0)
+    bc.power_off.assert_called_with(boards=[10], frame=0, cabinet=0)
     bc.power_off.reset_mock()
 
     e = OnDoneEvent()
-    abc.set_power(11, True, e)
+    requests = AtomicRequests(e)
+    requests.power(11, True)
+    abc.add_requests(requests)
     bc.power_on.side_effect = power_side_effect
     bc.power_off.side_effect = power_side_effect
     bc.read_fpga_register.side_effect = mock_read_fpga_register
     bc.read_bmp_version.side_effect = mock_read_bmp_version
     e.wait()
     assert e.success is success
-    bc.power_on.assert_called_once_with(boards=[11], frame=0, cabinet=0)
+    bc.power_on.assert_called_with(boards=[11], frame=0, cabinet=0)
     bc.power_on.reset_mock()
     assert len(bc.power_off.mock_calls) == 0
 
@@ -140,14 +145,16 @@ def test_set_power_blocks(abc, bc):
     bc.power_off.side_effect = (lambda *a, **k: event.wait())
 
     done_event = OnDoneEvent()
-    abc.set_power(10, False, done_event)
+    requests = AtomicRequests(done_event)
+    requests.power(10, False)
+    abc.add_requests(requests)
 
     # Block for a short time to ensure the background thread gets chance to
     # execute
     assert done_event.wait(0.1) is False
 
     # We should be sure the power command is blocking on the BMP call
-    bc.power_off.assert_called_once_with(boards=[10], frame=0, cabinet=0)
+    bc.power_off.assert_called_with(boards=[10], frame=0, cabinet=0)
 
     # When the BMP call completes, so should the done_event!
     event.set()
@@ -164,35 +171,40 @@ def test_set_power_merge(abc, bc, power_side_effect, success):
 
     # Make sure we can queue up several power commands which will get merged
     # (and any errors duplicated).
-    events = [OnDoneEvent() for _ in range(3)]
+    event = OnDoneEvent()
     with abc:
-        abc.set_power(10, False, events[0])
-        abc.set_power(11, False, events[1])
-        abc.set_power(13, False, events[2])
+        requests = AtomicRequests(event)
+        requests.power(10, False)
+        requests.power(11, False)
+        requests.power(13, False)
+        abc.add_requests(requests)
 
-    for event in events:
-        event.wait()
-        assert event.success is success
+    event.wait()
+    assert event.success is success
 
-    bc.power_off.assert_called_once_with(boards=[10, 11, 13], frame=0,
-                                         cabinet=0)
+    bc.power_off.assert_called_with(boards=[10, 11, 13], frame=0, cabinet=0)
 
 
 @pytest.mark.timeout(1.0)
 def test_set_power_dont_merge(abc, bc):
     # Make sure power commands are only merged with those of the same type
-    events = [OnDoneEvent() for _ in range(3)]
-    with abc:
-        abc.set_power(10, False, events[0])
-        abc.set_power(11, True, events[1])
-        abc.set_power(12, False, events[2])
+    bc.read_fpga_register.side_effect = mock_read_fpga_register
+    bc.read_bmp_version.side_effect = mock_read_bmp_version
 
-    for event in events:
-        event.wait()
+    event = OnDoneEvent()
+    with abc:
+        requests = AtomicRequests(event)
+        requests.power(10, False)
+        requests.power(11, True)
+        requests.power(12, False)
+        abc.add_requests(requests)
+
+    event.wait()
+
+    assert event.success
 
     assert bc.power_off.mock_calls == [
-        call(boards=[10], frame=0, cabinet=0),
-        call(boards=[12], frame=0, cabinet=0),
+        call(boards=[10, 12], frame=0, cabinet=0)
     ]
     assert bc.power_on.mock_calls == [
         call(boards=[11], frame=0, cabinet=0),
@@ -217,7 +229,9 @@ def test_set_link_enable(abc, bc, link, fpga, addr, enable, value,
     e = OnDoneEvent()
     bc.write_fpga_register.side_effect = side_effect
     bc.read_bmp_version.side_effect = mock_read_bmp_version
-    abc.set_link_enable(10, link, enable, e)
+    requests = AtomicRequests(e)
+    requests.link(10, link, enable)
+    abc.add_requests(requests)
     e.wait()
     assert e.success is success
     bc.write_fpga_register.assert_called_once_with(fpga, addr, value, board=10,
@@ -233,7 +247,9 @@ def test_set_link_enable_blocks(abc, bc):
     bc.read_bmp_version.side_effect = mock_read_bmp_version
 
     done_event = OnDoneEvent()
-    abc.set_link_enable(10, Links.east, True, done_event)
+    requests = AtomicRequests(done_event)
+    requests.link(10, Links.east, True)
+    abc.add_requests(requests)
 
     # Block for a short time to ensure the background thread gets chance to
     # execute
@@ -249,8 +265,8 @@ def test_set_link_enable_blocks(abc, bc):
 
 
 @pytest.mark.timeout(1.0)
-def test_power_no_priority(abc, bc):
-    # Make sure that power queue has higher priority
+def test_atomic_order(abc, bc):
+    # Make sure that requests are run in order
     power_on_event = threading.Event()
     power_off_event = threading.Event()
     link_event = threading.Event()
@@ -260,15 +276,17 @@ def test_power_no_priority(abc, bc):
     bc.read_fpga_register.side_effect = mock_read_fpga_register
     bc.read_bmp_version.side_effect = mock_read_bmp_version
 
+    event = OnDoneEvent()
+    requests = AtomicRequests(event)
     with abc:
-        e1, e2, e3 = (OnDoneEvent() for _ in range(3))
-        abc.set_power(10, True, e1)
-        abc.set_link_enable(11, Links.east, True, e2)
-        abc.set_power(12, False, e3)
+        requests.link(11, Links.east, True)
+        requests.power(12, False)
+        requests.power(10, True)
+        abc.add_requests(requests)
 
     # Block for a short time to ensure the background thread gets chance to
     # execute
-    assert e1.wait(0.1) is False
+    assert event.wait(0.1) is False
 
     # Make sure just the power command has been called
     bc.power_on.assert_called_once_with(boards=[10], frame=0, cabinet=0)
@@ -278,10 +296,9 @@ def test_power_no_priority(abc, bc):
 
     # Let the first power command complete
     power_on_event.set()
-    e1.wait(1.0)
 
     # Block for a short time to ensure background thread gets chance to execute
-    assert e2.wait(0.1) is False
+    assert event.wait(0.1) is False
 
     # We should be sure the power command is blocking on the BMP call
     assert len(bc.power_on.mock_calls) == 0
@@ -292,10 +309,9 @@ def test_power_no_priority(abc, bc):
 
     # Make BMP call complete and the last event finish
     link_event.set()
-    e2.wait(1.0)
 
     # Block for a short time to ensure background thread gets chance to execute
-    assert e3.wait(0.1) is False
+    assert event.wait(0.1) is False
 
     # Make sure just the power command has been called a second time (and not
     # the link setting command)
@@ -306,61 +322,25 @@ def test_power_no_priority(abc, bc):
 
     # Let the second power command complete
     power_off_event.set()
-    e3.wait(1.0)
-
-
-@pytest.mark.timeout(1.0)
-def test_power_removes_link_enables(abc, bc):
-    # Make sure link enable requests are removed for boards with newly added
-    # power commands.
-    bc.read_fpga_register.side_effect = mock_read_fpga_register
-    bc.read_bmp_version.side_effect = mock_read_bmp_version
-    with abc:
-        e1, e2, e3, e4 = (OnDoneEvent() for _ in range(4))
-        abc.set_power(10, True, e1)
-        abc.set_link_enable(10, Links.east, True, e2)
-        abc.set_link_enable(11, Links.east, True, e3)
-        abc.set_power(11, False, e4)
-
-    # Wait for the commands to complete
-    e1.wait()
-    e2.wait()
-    e3.wait()
-    e4.wait()
-
-    # All commands should have finished (but the link enable on board 11 should
-    # have failed)
-    assert e1.success is True
-    assert e2.success is True
-    assert e3.success is False
-    assert e4.success is True
-
-    # Make sure both power commands were sent
-    assert len(bc.power_on.mock_calls) == 1
-    assert len(bc.power_off.mock_calls) == 1
-
-    # But only one link command should be around
-    bc.write_fpga_register.assert_called_once_with(0, 0x5C, False, board=10,
-                                                   frame=0, cabinet=0)
+    event.wait(2.0)
 
 
 @pytest.mark.timeout(1.0)
 def test_stop_drains(abc, bc):
     # Make sure that the queues are emptied before the stop command is
     # processed
-    set_power_done = OnDoneEvent()
-    set_link_enable_done = OnDoneEvent()
+    event = OnDoneEvent()
     bc.read_bmp_version.side_effect = mock_read_bmp_version
     with abc:
-        abc.set_power(10, False, set_power_done)
-        abc.set_link_enable(11, Links.east, False, set_link_enable_done)
+        requests = AtomicRequests(event)
+        requests.power(10, False)
+        requests.link(11, Links.east, False)
+        abc.add_requests(requests)
         abc.stop()
 
     # Both of these should be carried out
-    set_power_done.wait()
-    set_link_enable_done.wait()
-    assert set_power_done.success is True
-    assert set_link_enable_done.success is True
+    event.wait(0.5)
+    assert event.success is True
 
     # And the loop should stop!
     abc.join()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -13,6 +13,7 @@ from spalloc_server.configuration import Machine
 from spalloc_server.controller import Controller, JobState
 from spalloc_server.links import Links
 from .common import simple_machine
+from spalloc_server.async_bmp_controller import AtomicRequests
 
 pytestmark = pytest.mark.usefixtures("mock_abc")
 
@@ -85,11 +86,12 @@ def test_mock_abc(mock_abc, expected_success):
 
     with abc:
         # If made atomically, should all fire at the end...
-        abc.set_power(None, None, cb)
-        abc.set_link_enable(None, None, None, cb)
+        requests = AtomicRequests(cb)
+        requests.power(None, None)
+        requests.link(None, None, None)
+        abc.add_requests(requests)
 
-        assert abc.set_power_calls == [(None, None, cb)]
-        assert abc.set_link_enable_calls == [(None, None, None, cb)]
+        assert abc.add_requests_calls == [requests]
 
         # Make sure the background thread gets some execution time
         time.sleep(0.05)
@@ -99,9 +101,8 @@ def test_mock_abc(mock_abc, expected_success):
     # Make sure the background thread gets some execution time
     time.sleep(0.05)
 
-    assert len(threads) == 2
+    assert len(threads) == 1
     assert threads[0] != threading.current_thread()
-    assert threads[1] != threading.current_thread()
 
     abc.stop()
     abc.join()
@@ -348,16 +349,17 @@ def test_create_job(conn, m):
         assert conn._jobs[job_id1].keepalive == 60.0
 
         # BMPs should have been told to power-on
-        assert all(_s is True for _b, _s, _f in controller.set_power_calls)
-        assert set(_b for _b, _s, _f in controller.set_power_calls) \
-            == set(range(3))
+        assert all(requests.power_on_boards == range(3)
+                   for requests in controller.add_requests_calls)
 
         # Links around the allocation should have been disabled
         assert all(_e is False
-                   for _b, _l, _e, _f in controller.set_link_enable_calls)
+                   for requests in controller.add_requests_calls
+                   for _b, _l, _e in requests.link_requests)
         assert (  # pragma: no branch
             set((_b, _l)
-                for _b, _l, _e, _f in controller.set_link_enable_calls) ==
+                for requests in controller.add_requests_calls
+                for _b, _l, _e in requests.link_requests) ==
             set((_b, _l)
                 for _b in range(3) for _l in Links
                 if board_down_link(0, 0, _b, _l, 1, 2)[:2] != (0, 0))
@@ -508,22 +510,23 @@ def test_power_on_job_boards(conn, m):
     time.sleep(0.05)
 
     controller = conn._bmp_controllers[m][(0, 0)]
-    controller.set_power_calls = []
-    controller.set_link_enable_calls = []
+    controller.add_requests_calls = []
 
     conn.power_on_job_boards(None, job_id)
 
+    # Should make a request
+    assert len(controller.add_requests_calls) == 1
+    requests = controller.add_requests_calls[0]
+
     # Should power cycle
-    assert len(controller.set_power_calls) == 1
-    assert controller.set_power_calls[0][0] == 0
-    assert controller.set_power_calls[0][1] is True
+    assert requests.power_on_boards == [0]
 
     # Should re-set up the links
-    assert len(controller.set_link_enable_calls) == 6
+    assert len(requests.link_requests) == 6
     assert all(
-        e is False for _b, _l, e, _f in controller.set_link_enable_calls)
+        e is False for _b, _l, e in requests.link_requests)
     assert (  # pragma: no branch
-        set((0, _l) for _b, _l, e, _f in controller.set_link_enable_calls) ==
+        set((0, _l) for _b, _l, e in requests.link_requests) ==
         set((0, _l) for _l in Links)
     )
 
@@ -542,18 +545,19 @@ def test_power_off_job_boards(conn, m):
     time.sleep(0.05)
 
     controller = conn._bmp_controllers[m][(0, 0)]
-    controller.set_power_calls = []
-    controller.set_link_enable_calls = []
+    controller.add_requests_calls = []
 
     conn.power_off_job_boards(None, job_id)
 
+    # Should add a request
+    assert len(controller.add_requests_calls) == 1
+    requests = controller.add_requests_calls[0]
+
     # Should power cycle
-    assert len(controller.set_power_calls) == 1
-    assert controller.set_power_calls[0][0] == 0
-    assert controller.set_power_calls[0][1] is False
+    assert requests.power_off_boards == [0]
 
     # Should not touch the links
-    assert len(controller.set_link_enable_calls) == 0
+    assert len(requests.link_requests) == 0
 
     # Shouldn't crash for non-existent job
     conn.power_off_job_boards(None, 1234)
@@ -570,10 +574,8 @@ def test_destroy_job(conn, m):
     job_id1 = conn.create_job(None, 1, 2, owner="me", keepalive=60.0)
     job_id2 = conn.create_job(None, 1, 2, owner="me", keepalive=60.0)
 
-    controller0.set_power_calls = []
-    controller1.set_power_calls = []
-    controller0.set_link_enable_calls = []
-    controller1.set_link_enable_calls = []
+    controller0.add_requests_calls = []
+    controller1.add_requests_calls = []
 
     # Should be able to kill queued jobs (and reasons should be prefixed to
     # indicate the job never started)
@@ -582,10 +584,8 @@ def test_destroy_job(conn, m):
     assert conn.get_job_state(None, job_id2).reason == "Cancelled: Because."
 
     # ...without powering anything down
-    assert controller0.set_power_calls == []
-    assert controller1.set_power_calls == []
-    assert controller0.set_link_enable_calls == []
-    assert controller1.set_link_enable_calls == []
+    assert controller0.add_requests_calls == []
+    assert controller1.add_requests_calls == []
 
     # Should be able to kill live jobs
     conn.destroy_job(None, job_id1, reason="Because you too.")
@@ -593,14 +593,16 @@ def test_destroy_job(conn, m):
     assert conn.get_job_state(None, job_id1).reason == "Because you too."
 
     # ...powering anything down that was in use
-    assert len(controller0.set_power_calls) == 3
-    assert len(controller1.set_power_calls) == 3
-    assert all(s is False for _b, s, _f in controller0.set_power_calls)
-    assert all(s is False for _b, s, _f in controller1.set_power_calls)
-    assert set(b for b, s, _ in controller0.set_power_calls) == set(range(3))
-    assert set(b for b, s, _ in controller1.set_power_calls) == set(range(3))
-    assert controller0.set_link_enable_calls == []
-    assert controller1.set_link_enable_calls == []
+    assert len(controller0.add_requests_calls) == 1
+    assert len(controller1.add_requests_calls) == 1
+    assert len(controller0.add_requests_calls[0].power_on_boards) == 0
+    assert len(controller1.add_requests_calls[0].power_on_boards) == 0
+    assert (set(controller0.add_requests_calls[0].power_off_boards) ==
+            set(range(3)))
+    assert (set(controller1.add_requests_calls[0].power_off_boards) ==
+            set(range(3)))
+    assert controller0.add_requests_calls[0].link_requests == []
+    assert controller1.add_requests_calls[0].link_requests == []
 
     # Shouldn't fail on bad job ids
     conn.destroy_job(None, 1234)
@@ -916,7 +918,7 @@ def test_bmp_on_request_complete(mock_abc, conn, m,
                     None, job_id).state == JobState.unknown
             else:
                 assert conn.get_job_state(None, job_id).state == mid_state
-            conn._bmp_on_request_complete(job, "mock", success)
+            conn._bmp_on_request_complete(job, success)
 
         assert conn.get_job_state(None, job_id).state == end_state
 
@@ -931,8 +933,7 @@ def test_set_job_power_and_links(mock_abc, conn, m, power, link_enable):
     time.sleep(0.05)
 
     controller = conn._bmp_controllers[m][(0, 0)]
-    controller.set_power_calls = []
-    controller.set_link_enable_calls = []
+    controller.add_requests_calls = []
 
     # Send the command while holding the lock to make sure we see the number of
     # BMP requests expected before a BMP gets chance to decrement the counter.
@@ -945,26 +946,26 @@ def test_set_job_power_and_links(mock_abc, conn, m, power, link_enable):
         assert job.power is power
 
         # Make sure the correct number of completions is requested
-        expected_requests = 1  # Power command always sent
-        if link_enable is not None:
-            expected_requests += 6
-        assert job.bmp_requests_until_ready == expected_requests
+        assert job.bmp_requests_until_ready == 1
 
         # Make sure the correct power commands were sent
-        assert len(controller.set_power_calls) == 1
-        assert controller.set_power_calls[0][0] == 0
-        assert controller.set_power_calls[0][1] == power
+        assert len(controller.add_requests_calls) == 1
+        if power:
+            assert controller.add_requests_calls[0].power_on_boards == [0]
+        else:
+            assert controller.add_requests_calls[0].power_off_boards == [0]
 
         if link_enable is not None:
-            assert len(controller.set_link_enable_calls) == 6
-            assert all(b == 0 for b, l, e, _ in
-                       controller.set_link_enable_calls)
-            assert all(e is link_enable for b, l, e, _ in
-                       controller.set_link_enable_calls)
-            assert set(l for b, l, e, _ in
-                       controller.set_link_enable_calls) == set(Links)
+            assert len(controller.add_requests_calls[0].link_requests) == 6
+            assert all(b == 0 for b, l, e in
+                       controller.add_requests_calls[0].link_requests)
+            assert all(e is link_enable for b, l, e in
+                       controller.add_requests_calls[0].link_requests)
+            assert set(l for b, l, e in
+                       controller.add_requests_calls[0].link_requests) ==\
+                set(Links)
         else:
-            assert len(controller.set_link_enable_calls) == 0
+            assert len(controller.add_requests_calls[0].link_requests) == 0
 
 
 def test_pickle(mock_abc):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -349,7 +349,7 @@ def test_create_job(conn, m):
         assert conn._jobs[job_id1].keepalive == 60.0
 
         # BMPs should have been told to power-on
-        assert all(requests.power_on_boards == range(3)
+        assert all(set(requests.power_on_boards) == set(range(3))
                    for requests in controller.add_requests_calls)
 
         # Links around the allocation should have been disabled


### PR DESCRIPTION
Long-outstanding pull request that simplifies the system to not allow requests to the BMP to be reordered.  This ensures that everything is atomic i.e. link and power requests all happen together for the same job.

This also adds in a 15 second retry on any request that fails, which is enough for a BMP to reset on "odd failures".

This branch is currently running the spalloc server and has been for some time, so it is certainly well tested!