### PR TITLE
Upgrade Travis Ubuntu distribution to bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 language: python
-dist: xenial
+dist: bionic
 python:
   - 2.7
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 language: python
-dist: bionic
+dist: focal
 python:
   - 2.7
   - 3.5


### PR DESCRIPTION
Upgrading Travis Ubuntu distribution to 18.04 (bionic) to help us with binaries that are close to the ITCM limit.

See https://github.com/orgs/SpiNNakerManchester/projects/32 for full list of PRs.